### PR TITLE
feat(catalog-builder): Add Azure Blob Storage upload support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Thumbs.db
 /tmp/
 
 # Generated output
+remote-catalog.json
 scoring_results/
 scoring_results_with_answers/
 scoring_results_readable/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ docker run -p 8501:8501 -p 8502:8502 azure-architecture-categoriser
 
 ```bash
 catalog-builder build-catalog --repo-path ./architecture-center --out catalog.json
+catalog-builder build-catalog --repo-path ./architecture-center --out catalog.json --upload-url "$CATALOG_BLOB_SAS_URL"
+catalog-builder upload --catalog catalog.json --blob-url "$CATALOG_BLOB_SAS_URL"
 catalog-builder stats --catalog catalog.json
 catalog-builder inspect --catalog catalog.json --family cloud_native
 
@@ -69,6 +71,7 @@ azure-architecture-categoriser/
 │   │   ├── extractor.py                 # Metadata extraction from architecture docs
 │   │   ├── detector.py                  # Architecture pattern detection heuristics
 │   │   ├── classifier.py                # AI-assisted classification
+│   │   ├── blob_upload.py               # Azure Blob Storage upload
 │   │   └── config.py                    # Configuration management (YAML)
 │   │
 │   ├── architecture_scorer/             # Scoring engine & CLI
@@ -271,6 +274,7 @@ docker compose down
 ### Optional Groups
 - `[recommendations-app]` - Streamlit, ReportLab, svglib, requests
 - `[gui]` - Streamlit
+- `[azure]` - azure-storage-blob, azure-identity (for blob upload)
 - `[dev]` - pytest, pytest-cov
 
 ## Important Files to Know

--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ catalog-builder build-catalog \
   --repo-path ./architecture-center \
   --out architecture-catalog.json
 
+# Build and upload catalog to Azure Blob Storage in one step
+catalog-builder build-catalog \
+  --repo-path ./architecture-center \
+  --out architecture-catalog.json \
+  --upload-url "$CATALOG_BLOB_SAS_URL"
+
+# Or upload an existing catalog separately
+catalog-builder upload \
+  --catalog architecture-catalog.json \
+  --blob-url "$CATALOG_BLOB_SAS_URL"
+
 # Score an application
 architecture-scorer score \
   --catalog architecture-catalog.json \
@@ -198,6 +209,9 @@ pip install -e ".[recommendations-app]"
 
 # With GUI catalog builder
 pip install -e ".[gui]"
+
+# With Azure Blob Storage upload support
+pip install -e ".[azure]"
 
 # Development
 pip install -e ".[dev]"
@@ -312,6 +326,7 @@ See [examples/context_files/README.md](examples/context_files/README.md) for the
 | [Architecture Scorer](https://adamswbrown.github.io/azure-architecture-categoriser/architecture-scorer.html) | Scoring engine details |
 | [Dr. Migrate Integration](https://adamswbrown.github.io/azure-architecture-categoriser/drmigrate-integration.html) | Get recommendations for ALL apps |
 | [Configuration](https://adamswbrown.github.io/azure-architecture-categoriser/configuration.html) | Full configuration reference |
+| [Blob Storage Upload](https://adamswbrown.github.io/azure-architecture-categoriser/blob-storage-upload.html) | Publish catalogs to Azure Blob Storage |
 | [Design Decisions](https://adamswbrown.github.io/azure-architecture-categoriser/design/) | Why does it work this way? |
 | [Azure Deployment](https://adamswbrown.github.io/azure-architecture-categoriser/azure-deployment.html) | Deploy to Azure Container Apps |
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,6 +13,7 @@ nav_links:
   - Scoring System: /architecture-scorer
   - Configuration: /configuration
   - Deployment: /azure-deployment
+  - Blob Storage Upload: /blob-storage-upload
   - Design Decisions: /design
 
 # Build settings

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -35,6 +35,7 @@
             <li><a href="{{ "/architecture-scorer.md" | relative_url }}">Architecture Scorer</a></li>
             <li><a href="{{ "/configuration.md" | relative_url }}">Configuration</a></li>
             <li><a href="{{ "/azure-deployment.md" | relative_url }}">Deployment</a></li>
+            <li><a href="{{ "/blob-storage-upload.md" | relative_url }}">Blob Storage Upload</a></li>
           </ul>
         </div>
 

--- a/docs/blob-storage-upload.md
+++ b/docs/blob-storage-upload.md
@@ -1,0 +1,298 @@
+---
+layout: default
+title: Blob Storage Upload
+---
+
+# Azure Blob Storage Upload
+
+The Catalog Builder can upload the generated `architecture-catalog.json` directly to Azure Blob Storage. This is useful for CI/CD pipelines where the catalog is built and then published to a known storage account for consumption by downstream services.
+
+## Installation
+
+Blob upload requires the `azure` optional dependency group:
+
+```bash
+pip install -e ".[azure]"
+```
+
+This installs:
+- `azure-storage-blob` -- Azure Blob Storage client
+- `azure-identity` -- DefaultAzureCredential support (managed identity, Azure CLI, OIDC)
+
+## Authentication Methods
+
+Three authentication methods are supported, in priority order:
+
+### 1. SAS URL (Recommended for CI/CD)
+
+A Shared Access Signature (SAS) URL embeds the authentication token directly in the URL. This is the simplest option for pipelines -- no SDK configuration needed beyond the URL itself.
+
+```bash
+# Blob-level SAS URL (uploads to exact blob path)
+catalog-builder upload \
+  --catalog architecture-catalog.json \
+  --blob-url "https://myaccount.blob.core.windows.net/catalogs/architecture-catalog.json?sv=2022-11-02&ss=b&srt=o&sp=cw&se=2025-12-31&sig=..."
+
+# Container-level SAS URL (blob name derived from filename)
+catalog-builder upload \
+  --catalog architecture-catalog.json \
+  --blob-url "https://myaccount.blob.core.windows.net/catalogs?sv=2022-11-02&ss=b&srt=co&sp=cw&se=2025-12-31&sig=..."
+```
+
+**Generating a SAS token** (Azure CLI):
+
+```bash
+# Generate a blob-level SAS URL valid for 24 hours
+az storage blob generate-sas \
+  --account-name myaccount \
+  --container-name catalogs \
+  --name architecture-catalog.json \
+  --permissions cw \
+  --expiry $(date -u -d "+24 hours" +%Y-%m-%dT%H:%MZ) \
+  --auth-mode login \
+  --as-user \
+  --full-uri
+
+# Generate a container-level SAS URL
+az storage container generate-sas \
+  --account-name myaccount \
+  --name catalogs \
+  --permissions cw \
+  --expiry $(date -u -d "+24 hours" +%Y-%m-%dT%H:%MZ) \
+  --auth-mode login \
+  --as-user
+```
+
+### 2. Connection String
+
+Standard Azure Storage connection string. Common for application configuration and local development.
+
+```bash
+catalog-builder upload \
+  --catalog architecture-catalog.json \
+  --connection-string "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=...;EndpointSuffix=core.windows.net" \
+  --container-name catalogs
+```
+
+You can also set the connection string via environment variable:
+
+```bash
+export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;..."
+catalog-builder upload --catalog architecture-catalog.json
+```
+
+### 3. DefaultAzureCredential
+
+Uses the Azure Identity library to authenticate via managed identity, Azure CLI, environment variables, or OIDC. Best for production environments with RBAC.
+
+```bash
+# Uses az login credentials, managed identity, or OIDC
+catalog-builder upload \
+  --catalog architecture-catalog.json \
+  --account-url "https://myaccount.blob.core.windows.net" \
+  --container-name catalogs
+```
+
+**Required RBAC role**: The identity needs `Storage Blob Data Contributor` on the target container.
+
+## CLI Reference
+
+### `upload` Command
+
+Upload an existing catalog file to Azure Blob Storage.
+
+```bash
+catalog-builder upload --catalog <path> [auth-options] [options]
+```
+
+| Option | Env Var | Description |
+|--------|---------|-------------|
+| `--catalog` | -- | Path to catalog JSON file (required) |
+| `--blob-url` | `CATALOG_BLOB_URL` | Full SAS URL (blob or container level) |
+| `--connection-string` | `AZURE_STORAGE_CONNECTION_STRING` | Storage account connection string |
+| `--account-url` | `AZURE_STORAGE_ACCOUNT_URL` | Storage account URL (for DefaultAzureCredential) |
+| `--container-name` | `CATALOG_CONTAINER_NAME` | Blob container name (default: `catalogs`) |
+| `--blob-name` | -- | Blob name (defaults to catalog filename) |
+| `--overwrite/--no-overwrite` | -- | Overwrite existing blob (default: overwrite) |
+| `-v, --verbose` | -- | Show detailed output |
+
+### `build-catalog --upload-url`
+
+Build and upload in a single step:
+
+```bash
+catalog-builder build-catalog \
+  --repo-path ./architecture-center \
+  --out architecture-catalog.json \
+  --upload-url "https://myaccount.blob.core.windows.net/catalogs/catalog.json?sv=..."
+```
+
+The `--upload-url` option accepts a SAS URL (same as `--blob-url` on the `upload` command). If the build succeeds, the catalog is uploaded automatically. The `CATALOG_BLOB_URL` environment variable is also supported.
+
+## Blob Metadata
+
+Uploaded blobs include metadata extracted from the catalog for easy inspection in Azure Portal:
+
+| Metadata Key | Example Value |
+|-------------|---------------|
+| `catalog_version` | `1.0.0` |
+| `total_architectures` | `50` |
+| `generated_at` | `2025-01-15T10:00:00Z` |
+| `source_commit` | `abc123def456` |
+| `source_repo` | `https://github.com/MicrosoftDocs/architecture-center` |
+
+The content type is set to `application/json` with UTF-8 encoding.
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+name: Build and Publish Catalog
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 6am UTC
+  workflow_dispatch:
+
+jobs:
+  build-catalog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -e ".[azure]"
+
+      - name: Clone Architecture Center
+        run: git clone --depth 1 https://github.com/MicrosoftDocs/architecture-center.git
+
+      - name: Build and upload catalog
+        env:
+          CATALOG_BLOB_URL: ${{ secrets.CATALOG_BLOB_SAS_URL }}
+        run: |
+          catalog-builder build-catalog \
+            --repo-path ./architecture-center \
+            --out architecture-catalog.json \
+            --upload-url "$CATALOG_BLOB_URL"
+```
+
+### GitHub Actions with OIDC
+
+For keyless authentication using federated identity:
+
+```yaml
+jobs:
+  build-catalog:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -e ".[azure]"
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Clone Architecture Center
+        run: git clone --depth 1 https://github.com/MicrosoftDocs/architecture-center.git
+
+      - name: Build catalog
+        run: |
+          catalog-builder build-catalog \
+            --repo-path ./architecture-center \
+            --out architecture-catalog.json
+
+      - name: Upload catalog
+        run: |
+          catalog-builder upload \
+            --catalog architecture-catalog.json \
+            --account-url "https://myaccount.blob.core.windows.net" \
+            --container-name catalogs
+```
+
+### Azure DevOps Pipelines
+
+```yaml
+trigger:
+  - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.11'
+
+  - script: pip install -e ".[azure]"
+    displayName: Install dependencies
+
+  - script: git clone --depth 1 https://github.com/MicrosoftDocs/architecture-center.git
+    displayName: Clone Architecture Center
+
+  - script: |
+      catalog-builder build-catalog \
+        --repo-path ./architecture-center \
+        --out architecture-catalog.json \
+        --upload-url "$(CATALOG_BLOB_SAS_URL)"
+    displayName: Build and upload catalog
+```
+
+## Troubleshooting
+
+### "Azure Blob Storage upload requires the 'azure' extras"
+
+Install the Azure dependencies:
+
+```bash
+pip install -e ".[azure]"
+```
+
+### "No authentication method provided"
+
+Supply at least one of `--blob-url`, `--connection-string`, or `--account-url`.
+
+### "The specified blob already exists" (409 Conflict)
+
+The blob already exists and `--no-overwrite` was specified. Either use `--overwrite` (the default) or delete the existing blob first.
+
+### "AuthorizationPermissionMismatch" (403 Forbidden)
+
+The SAS token or identity does not have write permissions on the target container. Ensure:
+- SAS tokens include `c` (create) and `w` (write) permissions
+- RBAC identities have `Storage Blob Data Contributor` role
+- The token has not expired
+
+### "ContainerNotFound" (404 Not Found)
+
+The target container does not exist. Create it first:
+
+```bash
+az storage container create \
+  --name catalogs \
+  --account-name myaccount \
+  --auth-mode login
+```
+
+## Related Documentation
+
+- [Catalog Builder](./catalog-builder.md) -- Building architecture catalogs
+- [Azure Deployment](./azure-deployment.md) -- Deploying the full application to Azure
+- [Configuration Reference](./configuration.md) -- Full configuration options

--- a/docs/catalog-builder.md
+++ b/docs/catalog-builder.md
@@ -62,6 +62,7 @@ catalog-builder build-catalog \
 | `--category` | Filter by Azure category (e.g., `containers`) |
 | `--product` | Filter by Azure product (supports prefix matching) |
 | `--require-yml` | Only include files with YamlMime:Architecture metadata |
+| `--upload-url` | Azure Blob Storage SAS URL to upload the catalog after building (env: `CATALOG_BLOB_URL`) |
 | `-v, --verbose` | Enable verbose output |
 
 ### list-filters
@@ -100,6 +101,30 @@ Display catalog statistics.
 ```bash
 catalog-builder stats --catalog architecture-catalog.json
 ```
+
+### upload
+
+Upload a catalog JSON file to Azure Blob Storage. Supports SAS URL, connection string, and DefaultAzureCredential authentication.
+
+```bash
+# Upload with SAS URL
+catalog-builder upload \
+  --catalog architecture-catalog.json \
+  --blob-url "https://acct.blob.core.windows.net/catalogs/catalog.json?sv=..."
+
+# Upload with connection string
+catalog-builder upload \
+  --catalog architecture-catalog.json \
+  --connection-string "DefaultEndpointsProtocol=https;..." \
+  --container-name catalogs
+
+# Upload with DefaultAzureCredential
+catalog-builder upload \
+  --catalog architecture-catalog.json \
+  --account-url "https://acct.blob.core.windows.net"
+```
+
+See [Blob Storage Upload](./blob-storage-upload.md) for full details, CI/CD examples, and troubleshooting.
 
 ### init-config
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -155,6 +155,32 @@ See [Catalog Builder Guide](./catalog-builder.md) for details on:
 - Adjusting scoring weights
 - Validating catalog quality
 
+### Publishing the Catalog to Azure Blob Storage
+
+After building a catalog, you can publish it to Azure Blob Storage so it can be shared across environments or consumed by other services.
+
+**Install the Azure extras:**
+```bash
+pip install -e ".[azure]"
+```
+
+**Build and upload in one step:**
+```bash
+catalog-builder build-catalog \
+  --repo-path ./architecture-center \
+  --out catalog.json \
+  --upload-url "https://myaccount.blob.core.windows.net/catalogs/catalog.json?sv=..."
+```
+
+**Or upload an existing catalog separately:**
+```bash
+catalog-builder upload \
+  --catalog architecture-catalog.json \
+  --blob-url "$CATALOG_BLOB_SAS_URL"
+```
+
+Three authentication methods are supported: SAS URLs, connection strings, and DefaultAzureCredential (managed identity). See [Blob Storage Upload](./blob-storage-upload.md) for full details and CI/CD examples.
+
 ### Batch Processing
 
 Process multiple applications programmatically:

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,7 @@ The core scoring engine that evaluates how well architectures match your applica
 - **[Architecture Scorer Documentation](./architecture-scorer.md)** - How the scoring algorithm works
 - **[Configuration Guide](./configuration.md)** - Customizing application behavior
 - **[Azure Deployment](./azure-deployment.md)** - Deploying to Azure
+- **[Blob Storage Upload](./blob-storage-upload.md)** - Publishing catalogs to Azure Blob Storage
 - **[Dr. Migrate Integration](./drmigrate-integration.md)** - Integrating with Dr. Migrate
 - **[Design Decisions](./design/)** - Technical design documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ recommendations-app = [
     "requests>=2.28.0",
     "svglib>=1.5.0",
 ]
+azure = [
+    "azure-storage-blob>=12.19.0",
+    "azure-identity>=1.15.0",
+]
 
 [project.scripts]
 catalog-builder = "catalog_builder.cli:main"

--- a/src/architecture_recommendations_app/utils/catalog_loader.py
+++ b/src/architecture_recommendations_app/utils/catalog_loader.py
@@ -1,101 +1,29 @@
-"""Secure remote catalog loading from URLs.
+"""Remote catalog loading for the web app.
 
-Downloads architecture catalog JSON files from remote URLs (e.g. Azure Blob
-Storage) with protections against malicious content:
-
-- URL validation via domain allowlist and SSRF checks
-- Response size cap to prevent memory exhaustion
-- JSON structure validation via Pydantic model
-- Architecture count ceiling to reject implausibly large payloads
-- Content-Type verification
-- Connection and read timeouts
+Thin wrapper around catalog_builder.catalog_download that resolves
+the save path relative to the project root (so the file persists
+across Streamlit reruns).
 """
 
-import json
-import logging
 from pathlib import Path
 from typing import Optional
-from urllib.parse import urlparse
 
-import requests
-
-from architecture_recommendations_app.utils.sanitize import (
-    BLOCKED_HOSTNAMES,
-    BLOCKED_IP_RANGES,
-    _is_ip_blocked,
+from catalog_builder.catalog_download import (
+    CATALOG_ALLOWED_DOMAINS,
+    MAX_ARCHITECTURE_COUNT,
+    MAX_CATALOG_BYTES,
+    CatalogDownloadError as CatalogLoadError,
+    download_catalog,
 )
 
-logger = logging.getLogger(__name__)
-
-# ── Limits ──────────────────────────────────────────────────────────────────
-MAX_CATALOG_BYTES = 50 * 1024 * 1024  # 50 MB - generous but bounded
-MAX_ARCHITECTURE_COUNT = 500  # no real-world catalog should exceed this
-REQUEST_TIMEOUT = (10, 30)  # (connect, read) seconds
-
-# Domains allowed for catalog downloads.
-# Uses suffix matching: "blob.core.windows.net" matches
-# "myaccount.blob.core.windows.net".
-CATALOG_ALLOWED_DOMAINS = frozenset([
-    # Azure Blob Storage (all clouds)
-    "blob.core.windows.net",
-    "blob.core.chinacloudapi.cn",
-    "blob.core.usgovcloudapi.net",
-    # Microsoft docs / CDN
-    "microsoft.com",
-    "azure.com",
-    "azureedge.net",
-    "akamaized.net",
-    "msecnd.net",
-    # GitHub (raw content / releases)
-    "github.com",
-    "githubusercontent.com",
-    "raw.githubusercontent.com",
-])
-
-
-class CatalogLoadError(Exception):
-    """Raised when a remote catalog cannot be loaded."""
-
-
-def _validate_catalog_url(
-    url: str,
-    allowed_domains: frozenset[str],
-) -> tuple[bool, str]:
-    """Validate a catalog URL with proper subdomain matching.
-
-    Unlike the shared validate_url (which uses a 2-part suffix), this
-    checks whether the hostname *ends with* any allowed domain, so
-    ``myaccount.blob.core.windows.net`` correctly matches
-    ``blob.core.windows.net``.
-    """
-    try:
-        parsed = urlparse(url)
-    except Exception:
-        return False, "Invalid URL format"
-
-    if parsed.scheme.lower() != "https":
-        return False, "URL scheme must be HTTPS"
-
-    if not parsed.netloc:
-        return False, "URL must have a hostname"
-
-    hostname = parsed.netloc.lower()
-    if ":" in hostname:
-        hostname = hostname.split(":")[0]
-
-    # Block cloud metadata / internal endpoints
-    if hostname in BLOCKED_HOSTNAMES:
-        return False, "URL hostname is blocked"
-
-    if _is_ip_blocked(hostname):
-        return False, "URL points to a private/internal IP address"
-
-    # Subdomain-aware allowlist check
-    for domain in allowed_domains:
-        if hostname == domain or hostname.endswith("." + domain):
-            return True, ""
-
-    return False, f"URL domain '{hostname}' is not in the allowed list"
+# Re-export for backwards compatibility with Recommendations.py
+__all__ = [
+    "CATALOG_ALLOWED_DOMAINS",
+    "MAX_ARCHITECTURE_COUNT",
+    "MAX_CATALOG_BYTES",
+    "CatalogLoadError",
+    "fetch_remote_catalog",
+]
 
 
 def fetch_remote_catalog(
@@ -105,150 +33,14 @@ def fetch_remote_catalog(
 ) -> tuple[dict, Path]:
     """Download, validate, and persist a remote catalog.
 
-    Args:
-        url: HTTPS URL pointing to a catalog JSON file.
-        allowed_domains: Override the domain allowlist (mainly for testing).
-
-    Returns:
-        Tuple of (catalog_dict, path_to_saved_file).
-        The saved file is written to the project-local directory so it
-        persists across Streamlit reruns.
-
-    Raises:
-        CatalogLoadError: On any validation or network failure.
+    Saves to ``<project_root>/remote-catalog.json`` so the file is
+    available across Streamlit session restarts.
     """
-    domains = allowed_domains or CATALOG_ALLOWED_DOMAINS
-
-    # ── 1. Validate URL ─────────────────────────────────────────────────
-    valid, err = _validate_catalog_url(url, domains)
-    if not valid:
-        raise CatalogLoadError(f"Invalid URL: {err}")
-
-    # ── 2. Download with size guard ─────────────────────────────────────
-    try:
-        resp = requests.get(
-            url,
-            timeout=REQUEST_TIMEOUT,
-            stream=True,
-            headers={"Accept": "application/json"},
-            allow_redirects=False,
-        )
-    except requests.ConnectionError:
-        raise CatalogLoadError("Could not connect to the catalog URL.")
-    except requests.Timeout:
-        raise CatalogLoadError("Request timed out while downloading the catalog.")
-    except requests.RequestException as exc:
-        raise CatalogLoadError(f"Network error: {exc}")
-
-    if resp.status_code in (301, 302):
-        raise CatalogLoadError(
-            "The URL returned a redirect. Please use the direct URL to the catalog file."
-        )
-
-    if resp.status_code != 200:
-        raise CatalogLoadError(
-            f"Server returned HTTP {resp.status_code}. "
-            "Check that the URL is correct and the resource is accessible."
-        )
-
-    # Verify content type if the server provides one
-    content_type = resp.headers.get("Content-Type", "")
-    if content_type and "json" not in content_type and "octet-stream" not in content_type:
-        raise CatalogLoadError(
-            f"Unexpected Content-Type '{content_type}'. Expected a JSON file."
-        )
-
-    # Read body in chunks, enforcing the size limit
-    chunks: list[bytes] = []
-    received = 0
-    for chunk in resp.iter_content(chunk_size=64 * 1024):
-        received += len(chunk)
-        if received > MAX_CATALOG_BYTES:
-            raise CatalogLoadError(
-                f"Catalog exceeds the maximum allowed size of "
-                f"{MAX_CATALOG_BYTES // (1024 * 1024)} MB."
-            )
-        chunks.append(chunk)
-
-    raw = b"".join(chunks)
-
-    if not raw:
-        raise CatalogLoadError("Downloaded file is empty.")
-
-    # ── 3. Parse JSON ───────────────────────────────────────────────────
-    try:
-        data = json.loads(raw)
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        raise CatalogLoadError(f"Downloaded file is not valid JSON: {exc}")
-
-    # ── 4. Structural validation ────────────────────────────────────────
-    _validate_catalog_structure(data)
-
-    # ── 5. Persist to local file ────────────────────────────────────────
     project_root = Path(__file__).parent.parent.parent.parent
     dest = project_root / "remote-catalog.json"
 
-    dest.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
-    logger.info("Remote catalog saved to %s", dest)
-
-    return data, dest
-
-
-def _validate_catalog_structure(data: dict) -> None:
-    """Validate the essential shape of a catalog without importing heavy models.
-
-    Checks performed:
-    - Top-level must be a dict
-    - Must contain an 'architectures' key with a list value
-    - Architecture count must be <= MAX_ARCHITECTURE_COUNT
-    - Each entry must have at least 'name' or 'architecture_id'
-    - 'version' field should be present
-    """
-    if not isinstance(data, dict):
-        raise CatalogLoadError(
-            "Catalog must be a JSON object with an 'architectures' key."
-        )
-
-    if "architectures" not in data:
-        raise CatalogLoadError(
-            "Catalog is missing the required 'architectures' field."
-        )
-
-    architectures = data["architectures"]
-    if not isinstance(architectures, list):
-        raise CatalogLoadError("'architectures' must be a JSON array.")
-
-    if len(architectures) == 0:
-        raise CatalogLoadError("Catalog contains no architectures.")
-
-    if len(architectures) > MAX_ARCHITECTURE_COUNT:
-        raise CatalogLoadError(
-            f"Catalog contains {len(architectures)} architectures, which exceeds "
-            f"the maximum of {MAX_ARCHITECTURE_COUNT}. This may not be a valid catalog."
-        )
-
-    if "version" not in data:
-        raise CatalogLoadError(
-            "Catalog is missing the 'version' field. This may not be a valid catalog file."
-        )
-
-    # Spot-check a few entries to make sure they look like architectures
-    for i, entry in enumerate(architectures[:5]):
-        if not isinstance(entry, dict):
-            raise CatalogLoadError(
-                f"Architecture entry at index {i} is not a JSON object."
-            )
-        if "name" not in entry and "architecture_id" not in entry:
-            raise CatalogLoadError(
-                f"Architecture entry at index {i} is missing both 'name' and "
-                f"'architecture_id'. This does not look like a valid catalog."
-            )
-
-    # Full Pydantic validation to catch schema drift or tampered payloads
-    try:
-        from catalog_builder.schema import ArchitectureCatalog
-        ArchitectureCatalog.model_validate(data)
-    except Exception as exc:
-        raise CatalogLoadError(
-            f"Catalog failed schema validation: {exc}"
-        )
+    return download_catalog(
+        url,
+        output=dest,
+        allowed_domains=allowed_domains,
+    )

--- a/src/architecture_recommendations_app/utils/catalog_loader.py
+++ b/src/architecture_recommendations_app/utils/catalog_loader.py
@@ -1,0 +1,254 @@
+"""Secure remote catalog loading from URLs.
+
+Downloads architecture catalog JSON files from remote URLs (e.g. Azure Blob
+Storage) with protections against malicious content:
+
+- URL validation via domain allowlist and SSRF checks
+- Response size cap to prevent memory exhaustion
+- JSON structure validation via Pydantic model
+- Architecture count ceiling to reject implausibly large payloads
+- Content-Type verification
+- Connection and read timeouts
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+import requests
+
+from architecture_recommendations_app.utils.sanitize import (
+    BLOCKED_HOSTNAMES,
+    BLOCKED_IP_RANGES,
+    _is_ip_blocked,
+)
+
+logger = logging.getLogger(__name__)
+
+# ── Limits ──────────────────────────────────────────────────────────────────
+MAX_CATALOG_BYTES = 50 * 1024 * 1024  # 50 MB - generous but bounded
+MAX_ARCHITECTURE_COUNT = 500  # no real-world catalog should exceed this
+REQUEST_TIMEOUT = (10, 30)  # (connect, read) seconds
+
+# Domains allowed for catalog downloads.
+# Uses suffix matching: "blob.core.windows.net" matches
+# "myaccount.blob.core.windows.net".
+CATALOG_ALLOWED_DOMAINS = frozenset([
+    # Azure Blob Storage (all clouds)
+    "blob.core.windows.net",
+    "blob.core.chinacloudapi.cn",
+    "blob.core.usgovcloudapi.net",
+    # Microsoft docs / CDN
+    "microsoft.com",
+    "azure.com",
+    "azureedge.net",
+    "akamaized.net",
+    "msecnd.net",
+    # GitHub (raw content / releases)
+    "github.com",
+    "githubusercontent.com",
+    "raw.githubusercontent.com",
+])
+
+
+class CatalogLoadError(Exception):
+    """Raised when a remote catalog cannot be loaded."""
+
+
+def _validate_catalog_url(
+    url: str,
+    allowed_domains: frozenset[str],
+) -> tuple[bool, str]:
+    """Validate a catalog URL with proper subdomain matching.
+
+    Unlike the shared validate_url (which uses a 2-part suffix), this
+    checks whether the hostname *ends with* any allowed domain, so
+    ``myaccount.blob.core.windows.net`` correctly matches
+    ``blob.core.windows.net``.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False, "Invalid URL format"
+
+    if parsed.scheme.lower() != "https":
+        return False, "URL scheme must be HTTPS"
+
+    if not parsed.netloc:
+        return False, "URL must have a hostname"
+
+    hostname = parsed.netloc.lower()
+    if ":" in hostname:
+        hostname = hostname.split(":")[0]
+
+    # Block cloud metadata / internal endpoints
+    if hostname in BLOCKED_HOSTNAMES:
+        return False, "URL hostname is blocked"
+
+    if _is_ip_blocked(hostname):
+        return False, "URL points to a private/internal IP address"
+
+    # Subdomain-aware allowlist check
+    for domain in allowed_domains:
+        if hostname == domain or hostname.endswith("." + domain):
+            return True, ""
+
+    return False, f"URL domain '{hostname}' is not in the allowed list"
+
+
+def fetch_remote_catalog(
+    url: str,
+    *,
+    allowed_domains: Optional[frozenset[str]] = None,
+) -> tuple[dict, Path]:
+    """Download, validate, and persist a remote catalog.
+
+    Args:
+        url: HTTPS URL pointing to a catalog JSON file.
+        allowed_domains: Override the domain allowlist (mainly for testing).
+
+    Returns:
+        Tuple of (catalog_dict, path_to_saved_file).
+        The saved file is written to the project-local directory so it
+        persists across Streamlit reruns.
+
+    Raises:
+        CatalogLoadError: On any validation or network failure.
+    """
+    domains = allowed_domains or CATALOG_ALLOWED_DOMAINS
+
+    # ── 1. Validate URL ─────────────────────────────────────────────────
+    valid, err = _validate_catalog_url(url, domains)
+    if not valid:
+        raise CatalogLoadError(f"Invalid URL: {err}")
+
+    # ── 2. Download with size guard ─────────────────────────────────────
+    try:
+        resp = requests.get(
+            url,
+            timeout=REQUEST_TIMEOUT,
+            stream=True,
+            headers={"Accept": "application/json"},
+            allow_redirects=False,
+        )
+    except requests.ConnectionError:
+        raise CatalogLoadError("Could not connect to the catalog URL.")
+    except requests.Timeout:
+        raise CatalogLoadError("Request timed out while downloading the catalog.")
+    except requests.RequestException as exc:
+        raise CatalogLoadError(f"Network error: {exc}")
+
+    if resp.status_code in (301, 302):
+        raise CatalogLoadError(
+            "The URL returned a redirect. Please use the direct URL to the catalog file."
+        )
+
+    if resp.status_code != 200:
+        raise CatalogLoadError(
+            f"Server returned HTTP {resp.status_code}. "
+            "Check that the URL is correct and the resource is accessible."
+        )
+
+    # Verify content type if the server provides one
+    content_type = resp.headers.get("Content-Type", "")
+    if content_type and "json" not in content_type and "octet-stream" not in content_type:
+        raise CatalogLoadError(
+            f"Unexpected Content-Type '{content_type}'. Expected a JSON file."
+        )
+
+    # Read body in chunks, enforcing the size limit
+    chunks: list[bytes] = []
+    received = 0
+    for chunk in resp.iter_content(chunk_size=64 * 1024):
+        received += len(chunk)
+        if received > MAX_CATALOG_BYTES:
+            raise CatalogLoadError(
+                f"Catalog exceeds the maximum allowed size of "
+                f"{MAX_CATALOG_BYTES // (1024 * 1024)} MB."
+            )
+        chunks.append(chunk)
+
+    raw = b"".join(chunks)
+
+    if not raw:
+        raise CatalogLoadError("Downloaded file is empty.")
+
+    # ── 3. Parse JSON ───────────────────────────────────────────────────
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise CatalogLoadError(f"Downloaded file is not valid JSON: {exc}")
+
+    # ── 4. Structural validation ────────────────────────────────────────
+    _validate_catalog_structure(data)
+
+    # ── 5. Persist to local file ────────────────────────────────────────
+    project_root = Path(__file__).parent.parent.parent.parent
+    dest = project_root / "remote-catalog.json"
+
+    dest.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+    logger.info("Remote catalog saved to %s", dest)
+
+    return data, dest
+
+
+def _validate_catalog_structure(data: dict) -> None:
+    """Validate the essential shape of a catalog without importing heavy models.
+
+    Checks performed:
+    - Top-level must be a dict
+    - Must contain an 'architectures' key with a list value
+    - Architecture count must be <= MAX_ARCHITECTURE_COUNT
+    - Each entry must have at least 'name' or 'architecture_id'
+    - 'version' field should be present
+    """
+    if not isinstance(data, dict):
+        raise CatalogLoadError(
+            "Catalog must be a JSON object with an 'architectures' key."
+        )
+
+    if "architectures" not in data:
+        raise CatalogLoadError(
+            "Catalog is missing the required 'architectures' field."
+        )
+
+    architectures = data["architectures"]
+    if not isinstance(architectures, list):
+        raise CatalogLoadError("'architectures' must be a JSON array.")
+
+    if len(architectures) == 0:
+        raise CatalogLoadError("Catalog contains no architectures.")
+
+    if len(architectures) > MAX_ARCHITECTURE_COUNT:
+        raise CatalogLoadError(
+            f"Catalog contains {len(architectures)} architectures, which exceeds "
+            f"the maximum of {MAX_ARCHITECTURE_COUNT}. This may not be a valid catalog."
+        )
+
+    if "version" not in data:
+        raise CatalogLoadError(
+            "Catalog is missing the 'version' field. This may not be a valid catalog file."
+        )
+
+    # Spot-check a few entries to make sure they look like architectures
+    for i, entry in enumerate(architectures[:5]):
+        if not isinstance(entry, dict):
+            raise CatalogLoadError(
+                f"Architecture entry at index {i} is not a JSON object."
+            )
+        if "name" not in entry and "architecture_id" not in entry:
+            raise CatalogLoadError(
+                f"Architecture entry at index {i} is missing both 'name' and "
+                f"'architecture_id'. This does not look like a valid catalog."
+            )
+
+    # Full Pydantic validation to catch schema drift or tampered payloads
+    try:
+        from catalog_builder.schema import ArchitectureCatalog
+        ArchitectureCatalog.model_validate(data)
+    except Exception as exc:
+        raise CatalogLoadError(
+            f"Catalog failed schema validation: {exc}"
+        )

--- a/src/catalog_builder/blob_upload.py
+++ b/src/catalog_builder/blob_upload.py
@@ -1,0 +1,208 @@
+"""Upload architecture catalog JSON to Azure Blob Storage."""
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+
+def _check_azure_deps():
+    """Check that Azure SDK dependencies are installed."""
+    try:
+        import azure.storage.blob  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "Azure Blob Storage upload requires the 'azure' extras.\n"
+            "Install with: pip install -e '.[azure]'"
+        )
+
+
+def _extract_catalog_metadata(catalog_path: Path) -> dict[str, str]:
+    """Extract key metadata from a catalog file for blob metadata.
+
+    Azure Blob metadata values must be strings.
+    """
+    with open(catalog_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    metadata = {}
+    if "version" in data:
+        metadata["catalog_version"] = str(data["version"])
+    if "total_architectures" in data:
+        metadata["total_architectures"] = str(data["total_architectures"])
+    if "generated_at" in data:
+        metadata["generated_at"] = str(data["generated_at"])
+    if "source_commit" in data and data["source_commit"]:
+        metadata["source_commit"] = str(data["source_commit"])[:12]
+    if "source_repo" in data:
+        metadata["source_repo"] = str(data["source_repo"])
+
+    return metadata
+
+
+def upload_catalog_to_blob(
+    catalog_path: Path,
+    *,
+    blob_url: Optional[str] = None,
+    connection_string: Optional[str] = None,
+    account_url: Optional[str] = None,
+    container_name: str = "catalogs",
+    blob_name: Optional[str] = None,
+    overwrite: bool = True,
+) -> str:
+    """Upload a catalog JSON file to Azure Blob Storage.
+
+    Authentication is resolved in priority order:
+    1. blob_url - Full SAS URL (blob-level or container-level + blob_name)
+    2. connection_string - Azure Storage connection string
+    3. account_url - Storage account URL with DefaultAzureCredential
+
+    Args:
+        catalog_path: Path to the catalog JSON file.
+        blob_url: Full blob SAS URL (e.g. https://account.blob.core.windows.net/container/blob?SAS).
+        connection_string: Azure Storage connection string.
+        account_url: Storage account URL for DefaultAzureCredential.
+        container_name: Blob container name (default: "catalogs").
+        blob_name: Blob name (defaults to the catalog filename).
+        overwrite: Whether to overwrite an existing blob.
+
+    Returns:
+        The URL of the uploaded blob (without SAS token).
+
+    Raises:
+        ImportError: If azure-storage-blob is not installed.
+        ValueError: If no authentication method is provided.
+        azure.core.exceptions.ResourceExistsError: If blob exists and overwrite=False.
+    """
+    _check_azure_deps()
+
+    if blob_name is None:
+        blob_name = catalog_path.name
+
+    metadata = _extract_catalog_metadata(catalog_path)
+
+    with open(catalog_path, "rb") as f:
+        catalog_data = f.read()
+
+    if blob_url:
+        return _upload_via_sas_url(
+            catalog_data, blob_url, blob_name, overwrite, metadata
+        )
+    elif connection_string:
+        return _upload_via_connection_string(
+            catalog_data, connection_string, container_name, blob_name, overwrite, metadata
+        )
+    elif account_url:
+        return _upload_via_default_credential(
+            catalog_data, account_url, container_name, blob_name, overwrite, metadata
+        )
+    else:
+        raise ValueError(
+            "No authentication method provided. Supply one of: "
+            "--blob-url, --connection-string, or --account-url"
+        )
+
+
+def _upload_via_sas_url(
+    data: bytes,
+    blob_url: str,
+    blob_name: str,
+    overwrite: bool,
+    metadata: dict[str, str],
+) -> str:
+    """Upload using a full SAS URL.
+
+    The URL can be either:
+    - A blob-level SAS URL (uploaded directly)
+    - A container-level SAS URL (blob_name is appended)
+    """
+    from azure.storage.blob import BlobClient, ContainerClient
+
+    # Heuristic: if the URL path has only one segment after the container,
+    # it's likely a container URL. If it has more, it's a blob URL.
+    # More reliably: try to detect if the path ends with just a container name.
+    from urllib.parse import urlparse
+    parsed = urlparse(blob_url.split("?")[0])
+    path_parts = [p for p in parsed.path.split("/") if p]
+
+    if len(path_parts) <= 1:
+        # Container-level SAS URL - append blob name
+        container_client = ContainerClient.from_container_url(blob_url)
+        blob_client = container_client.get_blob_client(blob_name)
+    else:
+        # Blob-level SAS URL - use directly
+        blob_client = BlobClient.from_blob_url(blob_url)
+
+    blob_client.upload_blob(
+        data,
+        overwrite=overwrite,
+        content_settings=_content_settings(),
+        metadata=metadata,
+    )
+
+    # Return the URL without SAS token
+    return blob_client.url.split("?")[0]
+
+
+def _upload_via_connection_string(
+    data: bytes,
+    connection_string: str,
+    container_name: str,
+    blob_name: str,
+    overwrite: bool,
+    metadata: dict[str, str],
+) -> str:
+    """Upload using an Azure Storage connection string."""
+    from azure.storage.blob import BlobServiceClient
+
+    service_client = BlobServiceClient.from_connection_string(connection_string)
+    blob_client = service_client.get_blob_client(
+        container=container_name, blob=blob_name
+    )
+
+    blob_client.upload_blob(
+        data,
+        overwrite=overwrite,
+        content_settings=_content_settings(),
+        metadata=metadata,
+    )
+
+    return blob_client.url
+
+
+def _upload_via_default_credential(
+    data: bytes,
+    account_url: str,
+    container_name: str,
+    blob_name: str,
+    overwrite: bool,
+    metadata: dict[str, str],
+) -> str:
+    """Upload using DefaultAzureCredential (managed identity, Azure CLI, etc.)."""
+    from azure.identity import DefaultAzureCredential
+    from azure.storage.blob import BlobServiceClient
+
+    credential = DefaultAzureCredential()
+    service_client = BlobServiceClient(account_url=account_url, credential=credential)
+    blob_client = service_client.get_blob_client(
+        container=container_name, blob=blob_name
+    )
+
+    blob_client.upload_blob(
+        data,
+        overwrite=overwrite,
+        content_settings=_content_settings(),
+        metadata=metadata,
+    )
+
+    return blob_client.url
+
+
+def _content_settings():
+    """Return ContentSettings for a JSON catalog upload."""
+    from azure.storage.blob import ContentSettings
+
+    return ContentSettings(
+        content_type="application/json",
+        content_encoding="utf-8",
+    )

--- a/src/catalog_builder/catalog_download.py
+++ b/src/catalog_builder/catalog_download.py
@@ -1,0 +1,263 @@
+"""Download architecture catalog JSON from a remote HTTPS URL.
+
+Provides secure remote catalog fetching with protections against
+malicious content:
+
+- URL validation via domain allowlist with subdomain matching
+- SSRF protection (blocked private IPs, cloud metadata endpoints)
+- Response size cap to prevent memory exhaustion
+- JSON structure validation and Pydantic schema checks
+- Architecture count ceiling to reject implausibly large payloads
+- Content-Type verification
+- Connection and read timeouts
+"""
+
+import ipaddress
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ── Limits ──────────────────────────────────────────────────────────────────
+MAX_CATALOG_BYTES = 50 * 1024 * 1024  # 50 MB
+MAX_ARCHITECTURE_COUNT = 500
+REQUEST_TIMEOUT = (10, 30)  # (connect, read) seconds
+
+# ── SSRF protection ─────────────────────────────────────────────────────────
+BLOCKED_IP_RANGES = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+BLOCKED_HOSTNAMES = frozenset([
+    "metadata.google.internal",
+    "metadata.goog",
+    "169.254.169.254",
+    "100.100.100.200",
+])
+
+# Domains allowed for catalog downloads (suffix matching).
+CATALOG_ALLOWED_DOMAINS = frozenset([
+    # Azure Blob Storage (all clouds)
+    "blob.core.windows.net",
+    "blob.core.chinacloudapi.cn",
+    "blob.core.usgovcloudapi.net",
+    # Microsoft docs / CDN
+    "microsoft.com",
+    "azure.com",
+    "azureedge.net",
+    "akamaized.net",
+    "msecnd.net",
+    # GitHub (raw content / releases)
+    "github.com",
+    "githubusercontent.com",
+    "raw.githubusercontent.com",
+])
+
+
+class CatalogDownloadError(Exception):
+    """Raised when a remote catalog cannot be downloaded or validated."""
+
+
+def _is_ip_blocked(hostname: str) -> bool:
+    """Check if a hostname is a blocked IP address."""
+    try:
+        ip = ipaddress.ip_address(hostname)
+        return any(ip in network for network in BLOCKED_IP_RANGES)
+    except ValueError:
+        return False
+
+
+def _validate_catalog_url(
+    url: str,
+    allowed_domains: frozenset[str],
+) -> tuple[bool, str]:
+    """Validate a catalog URL with subdomain matching and SSRF checks."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False, "Invalid URL format"
+
+    if parsed.scheme.lower() != "https":
+        return False, "URL scheme must be HTTPS"
+
+    if not parsed.netloc:
+        return False, "URL must have a hostname"
+
+    hostname = parsed.netloc.lower()
+    if ":" in hostname:
+        hostname = hostname.split(":")[0]
+
+    if hostname in BLOCKED_HOSTNAMES:
+        return False, "URL hostname is blocked"
+
+    if _is_ip_blocked(hostname):
+        return False, "URL points to a private/internal IP address"
+
+    for domain in allowed_domains:
+        if hostname == domain or hostname.endswith("." + domain):
+            return True, ""
+
+    return False, f"URL domain '{hostname}' is not in the allowed list"
+
+
+def _validate_catalog_structure(data: dict) -> None:
+    """Validate the essential shape of a catalog dict.
+
+    Checks:
+    - Top-level must be a dict with 'architectures' list
+    - Architecture count within bounds
+    - Each entry has 'name' or 'architecture_id'
+    - 'version' field present
+    - Full Pydantic schema validation
+    """
+    if not isinstance(data, dict):
+        raise CatalogDownloadError(
+            "Catalog must be a JSON object with an 'architectures' key."
+        )
+
+    if "architectures" not in data:
+        raise CatalogDownloadError(
+            "Catalog is missing the required 'architectures' field."
+        )
+
+    architectures = data["architectures"]
+    if not isinstance(architectures, list):
+        raise CatalogDownloadError("'architectures' must be a JSON array.")
+
+    if len(architectures) == 0:
+        raise CatalogDownloadError("Catalog contains no architectures.")
+
+    if len(architectures) > MAX_ARCHITECTURE_COUNT:
+        raise CatalogDownloadError(
+            f"Catalog contains {len(architectures)} architectures, which exceeds "
+            f"the maximum of {MAX_ARCHITECTURE_COUNT}. This may not be a valid catalog."
+        )
+
+    if "version" not in data:
+        raise CatalogDownloadError(
+            "Catalog is missing the 'version' field. This may not be a valid catalog file."
+        )
+
+    for i, entry in enumerate(architectures[:5]):
+        if not isinstance(entry, dict):
+            raise CatalogDownloadError(
+                f"Architecture entry at index {i} is not a JSON object."
+            )
+        if "name" not in entry and "architecture_id" not in entry:
+            raise CatalogDownloadError(
+                f"Architecture entry at index {i} is missing both 'name' and "
+                f"'architecture_id'. This does not look like a valid catalog."
+            )
+
+    # Full Pydantic validation
+    try:
+        from catalog_builder.schema import ArchitectureCatalog
+        ArchitectureCatalog.model_validate(data)
+    except Exception as exc:
+        raise CatalogDownloadError(
+            f"Catalog failed schema validation: {exc}"
+        )
+
+
+def download_catalog(
+    url: str,
+    *,
+    output: Optional[Path] = None,
+    allowed_domains: Optional[frozenset[str]] = None,
+) -> tuple[dict, Path]:
+    """Download, validate, and save a catalog from a remote URL.
+
+    Args:
+        url: HTTPS URL pointing to a catalog JSON file.
+        output: Where to save the file. Defaults to ``remote-catalog.json``
+            in the current working directory.
+        allowed_domains: Override the domain allowlist (for testing).
+
+    Returns:
+        Tuple of (catalog_dict, path_to_saved_file).
+
+    Raises:
+        CatalogDownloadError: On any validation or network failure.
+    """
+    domains = allowed_domains or CATALOG_ALLOWED_DOMAINS
+
+    # 1. Validate URL
+    valid, err = _validate_catalog_url(url, domains)
+    if not valid:
+        raise CatalogDownloadError(f"Invalid URL: {err}")
+
+    # 2. Download with size guard
+    try:
+        resp = requests.get(
+            url,
+            timeout=REQUEST_TIMEOUT,
+            stream=True,
+            headers={"Accept": "application/json"},
+            allow_redirects=False,
+        )
+    except requests.ConnectionError:
+        raise CatalogDownloadError("Could not connect to the catalog URL.")
+    except requests.Timeout:
+        raise CatalogDownloadError("Request timed out while downloading the catalog.")
+    except requests.RequestException as exc:
+        raise CatalogDownloadError(f"Network error: {exc}")
+
+    if resp.status_code in (301, 302):
+        raise CatalogDownloadError(
+            "The URL returned a redirect. Please use the direct URL to the catalog file."
+        )
+
+    if resp.status_code != 200:
+        raise CatalogDownloadError(
+            f"Server returned HTTP {resp.status_code}. "
+            "Check that the URL is correct and the resource is accessible."
+        )
+
+    content_type = resp.headers.get("Content-Type", "")
+    if content_type and "json" not in content_type and "octet-stream" not in content_type:
+        raise CatalogDownloadError(
+            f"Unexpected Content-Type '{content_type}'. Expected a JSON file."
+        )
+
+    chunks: list[bytes] = []
+    received = 0
+    for chunk in resp.iter_content(chunk_size=64 * 1024):
+        received += len(chunk)
+        if received > MAX_CATALOG_BYTES:
+            raise CatalogDownloadError(
+                f"Catalog exceeds the maximum allowed size of "
+                f"{MAX_CATALOG_BYTES // (1024 * 1024)} MB."
+            )
+        chunks.append(chunk)
+
+    raw = b"".join(chunks)
+    if not raw:
+        raise CatalogDownloadError("Downloaded file is empty.")
+
+    # 3. Parse JSON
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise CatalogDownloadError(f"Downloaded file is not valid JSON: {exc}")
+
+    # 4. Structural + schema validation
+    _validate_catalog_structure(data)
+
+    # 5. Persist
+    dest = output or Path("remote-catalog.json")
+    dest.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+    logger.info("Remote catalog saved to %s", dest)
+
+    return data, dest

--- a/src/catalog_builder/cli.py
+++ b/src/catalog_builder/cli.py
@@ -11,6 +11,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from .catalog import build_catalog, CatalogBuilder, CatalogValidator
 from .config import load_config, save_default_config, find_config_file, reset_config, get_config
 from .schema import ArchitectureCatalog, ExtractionConfidence, GenerationSettings
+from .blob_upload import upload_catalog_to_blob
 
 
 console = Console()
@@ -102,6 +103,13 @@ def main():
     envvar=['ANTHROPIC_API_KEY', 'OPENAI_API_KEY'],
     help='API key for LLM provider (or set ANTHROPIC_API_KEY/OPENAI_API_KEY env var)'
 )
+@click.option(
+    '--upload-url',
+    type=str,
+    envvar='CATALOG_BLOB_URL',
+    default=None,
+    help='Azure Blob Storage SAS URL to upload the catalog after building (or set CATALOG_BLOB_URL env var)'
+)
 def build_catalog_cmd(
     repo_path: Path,
     out: Path,
@@ -116,7 +124,8 @@ def build_catalog_cmd(
     extract_insights: bool,
     use_llm: bool,
     llm_provider: str,
-    api_key: str
+    api_key: str,
+    upload_url: str
 ):
     """Build the architecture catalog from source documentation.
 
@@ -246,6 +255,22 @@ def build_catalog_cmd(
             console.print(f"  ... and {len(issues) - 20} more")
 
     console.print(f"\n[green]✓[/green] Catalog saved to: {out}")
+
+    # Upload to Azure Blob Storage if requested
+    if upload_url:
+        try:
+            console.print(f"\n[bold blue]Uploading to Azure Blob Storage...[/bold blue]")
+            blob_url = upload_catalog_to_blob(out, blob_url=upload_url)
+            console.print(f"[green]✓[/green] Uploaded to: {blob_url}")
+        except ImportError as e:
+            console.print(f"\n[red]Error:[/red] {e}")
+            sys.exit(1)
+        except Exception as e:
+            console.print(f"\n[red]Upload failed:[/red] {e}")
+            if verbose:
+                import traceback
+                console.print(traceback.format_exc())
+            sys.exit(1)
 
 
 @main.command(name='init-config')
@@ -868,6 +893,140 @@ def _print_product_prefixes(products):
         table.add_row(prefix, str(count), ", ".join(examples))
 
     console.print(table)
+
+
+@main.command()
+@click.option(
+    '--catalog',
+    type=click.Path(exists=True, path_type=Path),
+    required=True,
+    help='Path to the catalog JSON file to upload'
+)
+@click.option(
+    '--blob-url',
+    type=str,
+    envvar='CATALOG_BLOB_URL',
+    default=None,
+    help='Full Azure Blob SAS URL (blob-level or container-level). Env: CATALOG_BLOB_URL'
+)
+@click.option(
+    '--connection-string',
+    type=str,
+    envvar='AZURE_STORAGE_CONNECTION_STRING',
+    default=None,
+    help='Azure Storage connection string. Env: AZURE_STORAGE_CONNECTION_STRING'
+)
+@click.option(
+    '--account-url',
+    type=str,
+    envvar='AZURE_STORAGE_ACCOUNT_URL',
+    default=None,
+    help='Storage account URL (uses DefaultAzureCredential). Env: AZURE_STORAGE_ACCOUNT_URL'
+)
+@click.option(
+    '--container-name',
+    type=str,
+    envvar='CATALOG_CONTAINER_NAME',
+    default='catalogs',
+    help='Blob container name (default: catalogs). Env: CATALOG_CONTAINER_NAME'
+)
+@click.option(
+    '--blob-name',
+    type=str,
+    default=None,
+    help='Blob name in the container (defaults to the catalog filename)'
+)
+@click.option(
+    '--overwrite/--no-overwrite',
+    default=True,
+    help='Whether to overwrite an existing blob (default: overwrite)'
+)
+@click.option(
+    '--verbose', '-v',
+    is_flag=True,
+    help='Show detailed output'
+)
+def upload(
+    catalog: Path,
+    blob_url: str,
+    connection_string: str,
+    account_url: str,
+    container_name: str,
+    blob_name: str,
+    overwrite: bool,
+    verbose: bool,
+):
+    """Upload a catalog JSON file to Azure Blob Storage.
+
+    Supports three authentication methods (in priority order):
+
+    \b
+    1. SAS URL (--blob-url): Full blob or container URL with SAS token.
+       Simplest option for CI/CD pipelines.
+    2. Connection string (--connection-string): Standard Azure Storage
+       connection string with --container-name.
+    3. DefaultAzureCredential (--account-url): Uses managed identity,
+       Azure CLI, or OIDC. Best for production with RBAC.
+
+    Examples:
+
+    \b
+        # Upload with a blob-level SAS URL
+        catalog-builder upload --catalog catalog.json \\
+          --blob-url "https://acct.blob.core.windows.net/catalogs/catalog.json?sv=..."
+
+    \b
+        # Upload with a connection string
+        catalog-builder upload --catalog catalog.json \\
+          --connection-string "DefaultEndpointsProtocol=https;..."
+
+    \b
+        # Upload with DefaultAzureCredential (managed identity / az login)
+        catalog-builder upload --catalog catalog.json \\
+          --account-url "https://acct.blob.core.windows.net"
+    """
+    if not blob_url and not connection_string and not account_url:
+        console.print(
+            "[red]Error:[/red] Provide one of --blob-url, --connection-string, or --account-url"
+        )
+        sys.exit(1)
+
+    # Determine auth method for display
+    if blob_url:
+        auth_method = "SAS URL"
+    elif connection_string:
+        auth_method = "Connection String"
+    else:
+        auth_method = "DefaultAzureCredential"
+
+    console.print(f"\n[bold blue]Azure Blob Storage Upload[/bold blue]")
+    console.print(f"Catalog: {catalog}")
+    console.print(f"Auth: {auth_method}")
+    console.print(f"Container: {container_name}")
+    console.print(f"Blob name: {blob_name or catalog.name}")
+    console.print(f"Overwrite: {overwrite}")
+    console.print()
+
+    try:
+        result_url = upload_catalog_to_blob(
+            catalog,
+            blob_url=blob_url,
+            connection_string=connection_string,
+            account_url=account_url,
+            container_name=container_name,
+            blob_name=blob_name,
+            overwrite=overwrite,
+        )
+        console.print(f"[green]✓[/green] Uploaded successfully to: {result_url}")
+    except ImportError as e:
+        console.print(f"\n[red]Error:[/red] {e}")
+        sys.exit(1)
+    except Exception as e:
+        console.print(f"\n[red]Upload failed:[/red] {e}")
+        if verbose:
+            import traceback
+            console.print(traceback.format_exc())
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/tests/test_blob_upload.py
+++ b/tests/test_blob_upload.py
@@ -1,0 +1,385 @@
+"""Tests for Azure Blob Storage upload functionality."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from catalog_builder.blob_upload import (
+    _check_azure_deps,
+    _extract_catalog_metadata,
+    upload_catalog_to_blob,
+)
+
+
+# --- Sample catalog fixture ---
+
+SAMPLE_CATALOG = {
+    "version": "1.0.0",
+    "generated_at": "2025-01-15T10:00:00Z",
+    "source_repo": "https://github.com/MicrosoftDocs/architecture-center",
+    "source_commit": "abc123def456789",
+    "total_architectures": 50,
+    "architectures": [],
+}
+
+
+@pytest.fixture
+def catalog_file(tmp_path):
+    """Create a temporary catalog JSON file."""
+    path = tmp_path / "architecture-catalog.json"
+    path.write_text(json.dumps(SAMPLE_CATALOG), encoding="utf-8")
+    return path
+
+
+# --- Metadata extraction tests ---
+
+
+class TestExtractCatalogMetadata:
+    """Tests for _extract_catalog_metadata."""
+
+    def test_extracts_all_fields(self, catalog_file):
+        metadata = _extract_catalog_metadata(catalog_file)
+        assert metadata["catalog_version"] == "1.0.0"
+        assert metadata["total_architectures"] == "50"
+        assert metadata["generated_at"] == "2025-01-15T10:00:00Z"
+        assert metadata["source_commit"] == "abc123def456"
+        assert metadata["source_repo"] == "https://github.com/MicrosoftDocs/architecture-center"
+
+    def test_handles_missing_optional_fields(self, tmp_path):
+        path = tmp_path / "minimal.json"
+        path.write_text(json.dumps({"architectures": []}), encoding="utf-8")
+        metadata = _extract_catalog_metadata(path)
+        assert "source_commit" not in metadata
+        assert "catalog_version" not in metadata
+
+    def test_truncates_long_commit(self, tmp_path):
+        path = tmp_path / "long_commit.json"
+        data = {**SAMPLE_CATALOG, "source_commit": "a" * 40}
+        path.write_text(json.dumps(data), encoding="utf-8")
+        metadata = _extract_catalog_metadata(path)
+        assert len(metadata["source_commit"]) == 12
+
+    def test_handles_null_commit(self, tmp_path):
+        path = tmp_path / "null_commit.json"
+        data = {**SAMPLE_CATALOG, "source_commit": None}
+        path.write_text(json.dumps(data), encoding="utf-8")
+        metadata = _extract_catalog_metadata(path)
+        assert "source_commit" not in metadata
+
+
+# --- Dependency check tests ---
+
+
+class TestCheckAzureDeps:
+    """Tests for _check_azure_deps."""
+
+    def test_raises_when_azure_not_installed(self):
+        """Missing azure-storage-blob raises ImportError with install hint."""
+        import importlib
+        import sys
+
+        # Temporarily remove azure.storage.blob from importable modules
+        with patch.dict(sys.modules, {"azure.storage.blob": None, "azure": None}):
+            with patch("builtins.__import__", side_effect=ImportError("No module")):
+                with pytest.raises(ImportError, match="pip install"):
+                    _check_azure_deps()
+
+
+# --- Upload function tests ---
+
+
+class TestUploadCatalogToBlob:
+    """Tests for upload_catalog_to_blob."""
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    def test_raises_without_auth(self, mock_deps, catalog_file):
+        """Must provide at least one auth method."""
+        with pytest.raises(ValueError, match="No authentication method"):
+            upload_catalog_to_blob(catalog_file)
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    @patch("catalog_builder.blob_upload._upload_via_sas_url")
+    def test_sas_url_takes_priority(self, mock_sas, mock_deps, catalog_file):
+        mock_sas.return_value = "https://acct.blob.core.windows.net/c/b"
+
+        result = upload_catalog_to_blob(
+            catalog_file,
+            blob_url="https://acct.blob.core.windows.net/c/b?sv=2021",
+            connection_string="DefaultEndpointsProtocol=https;...",
+        )
+
+        mock_sas.assert_called_once()
+        assert result == "https://acct.blob.core.windows.net/c/b"
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    @patch("catalog_builder.blob_upload._upload_via_connection_string")
+    def test_connection_string_used_when_no_sas(self, mock_conn, mock_deps, catalog_file):
+        mock_conn.return_value = "https://acct.blob.core.windows.net/catalogs/architecture-catalog.json"
+
+        upload_catalog_to_blob(
+            catalog_file,
+            connection_string="DefaultEndpointsProtocol=https;AccountName=acct;...",
+            container_name="catalogs",
+        )
+
+        mock_conn.assert_called_once()
+        args = mock_conn.call_args
+        assert args[0][1] == "DefaultEndpointsProtocol=https;AccountName=acct;..."
+        assert args[0][2] == "catalogs"
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    @patch("catalog_builder.blob_upload._upload_via_default_credential")
+    def test_default_credential_used_as_fallback(self, mock_dc, mock_deps, catalog_file):
+        mock_dc.return_value = "https://acct.blob.core.windows.net/catalogs/architecture-catalog.json"
+
+        upload_catalog_to_blob(
+            catalog_file,
+            account_url="https://acct.blob.core.windows.net",
+            container_name="mycontainer",
+        )
+
+        mock_dc.assert_called_once()
+        args = mock_dc.call_args
+        assert args[0][1] == "https://acct.blob.core.windows.net"
+        assert args[0][2] == "mycontainer"
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    @patch("catalog_builder.blob_upload._upload_via_sas_url")
+    def test_default_blob_name_is_filename(self, mock_sas, mock_deps, catalog_file):
+        mock_sas.return_value = "https://acct.blob.core.windows.net/c/architecture-catalog.json"
+
+        upload_catalog_to_blob(catalog_file, blob_url="https://acct.blob.core.windows.net/c/b?sv=2021")
+
+        args = mock_sas.call_args
+        # blob_name should be the catalog filename
+        assert args[0][2] == "architecture-catalog.json"
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    @patch("catalog_builder.blob_upload._upload_via_sas_url")
+    def test_custom_blob_name(self, mock_sas, mock_deps, catalog_file):
+        mock_sas.return_value = "https://acct.blob.core.windows.net/c/custom.json"
+
+        upload_catalog_to_blob(
+            catalog_file,
+            blob_url="https://acct.blob.core.windows.net/c/b?sv=2021",
+            blob_name="custom.json",
+        )
+
+        args = mock_sas.call_args
+        assert args[0][2] == "custom.json"
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    @patch("catalog_builder.blob_upload._upload_via_connection_string")
+    def test_overwrite_flag_passed_through(self, mock_conn, mock_deps, catalog_file):
+        mock_conn.return_value = "https://acct.blob.core.windows.net/c/b"
+
+        upload_catalog_to_blob(
+            catalog_file,
+            connection_string="conn",
+            overwrite=False,
+        )
+
+        args = mock_conn.call_args
+        assert args[0][4] is False  # overwrite parameter
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    @patch("catalog_builder.blob_upload._upload_via_connection_string")
+    def test_default_container_name(self, mock_conn, mock_deps, catalog_file):
+        mock_conn.return_value = "https://acct.blob.core.windows.net/catalogs/b"
+
+        upload_catalog_to_blob(catalog_file, connection_string="conn")
+
+        args = mock_conn.call_args
+        assert args[0][2] == "catalogs"  # default container name
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    @patch("catalog_builder.blob_upload._upload_via_sas_url")
+    def test_metadata_passed_to_upload(self, mock_sas, mock_deps, catalog_file):
+        mock_sas.return_value = "https://acct.blob.core.windows.net/c/b"
+
+        upload_catalog_to_blob(catalog_file, blob_url="https://acct.blob.core.windows.net/c/b?sv=2021")
+
+        args = mock_sas.call_args
+        metadata = args[0][4]  # metadata parameter
+        assert "catalog_version" in metadata
+        assert metadata["total_architectures"] == "50"
+
+
+# --- SAS URL path parsing tests ---
+
+
+class TestSasUrlParsing:
+    """Tests that SAS URL parsing correctly distinguishes blob vs container URLs.
+
+    These tests exercise the public upload_catalog_to_blob function with
+    _upload_via_sas_url mocked, since the Azure SDK is not installed in tests.
+    """
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    @patch("catalog_builder.blob_upload._upload_via_sas_url")
+    def test_blob_level_url_passes_full_url(self, mock_sas, mock_deps, catalog_file):
+        """A blob-level SAS URL (multi-segment path) is passed through."""
+        mock_sas.return_value = "https://acct.blob.core.windows.net/container/blob.json"
+
+        result = upload_catalog_to_blob(
+            catalog_file,
+            blob_url="https://acct.blob.core.windows.net/container/blob.json?sv=2021",
+        )
+
+        mock_sas.assert_called_once()
+        assert result == "https://acct.blob.core.windows.net/container/blob.json"
+
+    @patch("catalog_builder.blob_upload._check_azure_deps")
+    @patch("catalog_builder.blob_upload._upload_via_sas_url")
+    def test_container_level_url_passes_through(self, mock_sas, mock_deps, catalog_file):
+        """A container-level SAS URL (single-segment path) is passed through."""
+        mock_sas.return_value = "https://acct.blob.core.windows.net/container/architecture-catalog.json"
+
+        result = upload_catalog_to_blob(
+            catalog_file,
+            blob_url="https://acct.blob.core.windows.net/container?sv=2021",
+        )
+
+        mock_sas.assert_called_once()
+        # blob_name defaults to the filename
+        args = mock_sas.call_args[0]
+        assert args[2] == "architecture-catalog.json"  # blob_name
+
+
+# --- CLI integration tests ---
+
+
+class TestUploadCLI:
+    """Tests for the upload CLI command."""
+
+    def test_upload_command_exists(self):
+        """The upload command is registered."""
+        from click.testing import CliRunner
+        from catalog_builder.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["upload", "--help"])
+        assert result.exit_code == 0
+        assert "Azure Blob Storage" in result.output
+
+    def test_upload_requires_auth(self, catalog_file):
+        """Upload fails without any auth option."""
+        from click.testing import CliRunner
+        from catalog_builder.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["upload", "--catalog", str(catalog_file)])
+        assert result.exit_code != 0
+        assert "Provide one of" in result.output
+
+    def test_build_catalog_has_upload_url_option(self):
+        """The build-catalog command has --upload-url option."""
+        from click.testing import CliRunner
+        from catalog_builder.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["build-catalog", "--help"])
+        assert result.exit_code == 0
+        assert "--upload-url" in result.output
+
+    def test_upload_shows_auth_method(self, catalog_file):
+        """Upload displays which auth method is being used."""
+        from click.testing import CliRunner
+        from catalog_builder.cli import main
+
+        runner = CliRunner()
+
+        with patch("catalog_builder.cli.upload_catalog_to_blob") as mock_upload:
+            mock_upload.return_value = "https://acct.blob.core.windows.net/c/b"
+            result = runner.invoke(main, [
+                "upload",
+                "--catalog", str(catalog_file),
+                "--blob-url", "https://acct.blob.core.windows.net/c/b?sv=2021",
+            ])
+
+        assert "SAS URL" in result.output
+        assert result.exit_code == 0
+
+    def test_upload_handles_import_error(self, catalog_file):
+        """Upload shows helpful error when azure SDK is missing."""
+        from click.testing import CliRunner
+        from catalog_builder.cli import main
+
+        runner = CliRunner()
+
+        with patch("catalog_builder.cli.upload_catalog_to_blob") as mock_upload:
+            mock_upload.side_effect = ImportError(
+                "Azure Blob Storage upload requires the 'azure' extras.\n"
+                "Install with: pip install -e '.[azure]'"
+            )
+            result = runner.invoke(main, [
+                "upload",
+                "--catalog", str(catalog_file),
+                "--blob-url", "https://acct.blob.core.windows.net/c/b?sv=2021",
+            ])
+
+        assert result.exit_code != 0
+        assert "pip install" in result.output
+
+    def test_upload_with_connection_string(self, catalog_file):
+        """Upload works with connection string auth."""
+        from click.testing import CliRunner
+        from catalog_builder.cli import main
+
+        runner = CliRunner()
+
+        with patch("catalog_builder.cli.upload_catalog_to_blob") as mock_upload:
+            mock_upload.return_value = "https://acct.blob.core.windows.net/catalogs/b"
+            result = runner.invoke(main, [
+                "upload",
+                "--catalog", str(catalog_file),
+                "--connection-string", "DefaultEndpointsProtocol=https;AccountName=acct;...",
+                "--container-name", "mycontainer",
+            ])
+
+        assert "Connection String" in result.output
+        assert result.exit_code == 0
+        mock_upload.assert_called_once()
+        kwargs = mock_upload.call_args.kwargs
+        assert kwargs["connection_string"] == "DefaultEndpointsProtocol=https;AccountName=acct;..."
+        assert kwargs["container_name"] == "mycontainer"
+
+    def test_upload_with_account_url(self, catalog_file):
+        """Upload works with DefaultAzureCredential auth."""
+        from click.testing import CliRunner
+        from catalog_builder.cli import main
+
+        runner = CliRunner()
+
+        with patch("catalog_builder.cli.upload_catalog_to_blob") as mock_upload:
+            mock_upload.return_value = "https://acct.blob.core.windows.net/catalogs/b"
+            result = runner.invoke(main, [
+                "upload",
+                "--catalog", str(catalog_file),
+                "--account-url", "https://acct.blob.core.windows.net",
+            ])
+
+        assert "DefaultAzureCredential" in result.output
+        assert result.exit_code == 0
+
+    def test_upload_no_overwrite(self, catalog_file):
+        """Upload passes --no-overwrite flag correctly."""
+        from click.testing import CliRunner
+        from catalog_builder.cli import main
+
+        runner = CliRunner()
+
+        with patch("catalog_builder.cli.upload_catalog_to_blob") as mock_upload:
+            mock_upload.return_value = "https://acct.blob.core.windows.net/c/b"
+            result = runner.invoke(main, [
+                "upload",
+                "--catalog", str(catalog_file),
+                "--blob-url", "https://acct.blob.core.windows.net/c/b?sv=2021",
+                "--no-overwrite",
+            ])
+
+        kwargs = mock_upload.call_args.kwargs
+        assert kwargs["overwrite"] is False

--- a/tests/test_catalog_download_cli.py
+++ b/tests/test_catalog_download_cli.py
@@ -1,0 +1,193 @@
+"""Tests for the catalog download CLI command and --catalog-url option."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from catalog_builder.cli import main as catalog_builder_cli
+from architecture_scorer.cli import main as scorer_cli
+
+# Reuse the catalog factory from the download tests
+VALID_CATALOG = {
+    "version": "1.0.0",
+    "generated_at": "2025-01-15T10:00:00",
+    "source_repo": "https://github.com/MicrosoftDocs/architecture-center",
+    "source_commit": "abc123",
+    "total_architectures": 2,
+    "architectures": [
+        {
+            "architecture_id": f"arch-{i}",
+            "name": f"Architecture {i}",
+            "description": f"Test architecture {i}",
+            "source_repo_path": f"docs/arch-{i}",
+            "family": "paas",
+            "workload_domain": "web",
+        }
+        for i in range(2)
+    ],
+}
+
+_DOWNLOAD_PATCH = "catalog_builder.catalog_download.download_catalog"
+_BLOB_URL = "https://myaccount.blob.core.windows.net/catalogs/catalog.json"
+
+
+# === catalog-builder download ===
+
+
+class TestCatalogBuilderDownloadCLI:
+    """Tests for the 'catalog-builder download' command."""
+
+    def test_download_help(self):
+        runner = CliRunner()
+        result = runner.invoke(catalog_builder_cli, ["download", "--help"])
+        assert result.exit_code == 0
+        assert "Download a catalog from a remote URL" in result.output
+
+    @patch("catalog_builder.cli.download_catalog")
+    def test_download_success(self, mock_download, tmp_path):
+        dest = tmp_path / "catalog.json"
+        mock_download.return_value = (VALID_CATALOG, dest)
+
+        runner = CliRunner()
+        result = runner.invoke(catalog_builder_cli, [
+            "download",
+            "--url", _BLOB_URL,
+            "--out", str(dest),
+        ])
+
+        assert result.exit_code == 0
+        assert "2 architectures" in result.output
+        mock_download.assert_called_once_with(_BLOB_URL, output=dest)
+
+    @patch("catalog_builder.cli.download_catalog")
+    def test_download_verbose_shows_settings(self, mock_download, tmp_path):
+        dest = tmp_path / "catalog.json"
+        catalog_with_settings = {
+            **VALID_CATALOG,
+            "generation_settings": {
+                "allowed_topics": ["reference-architecture"],
+                "exclude_examples": True,
+            },
+        }
+        mock_download.return_value = (catalog_with_settings, dest)
+
+        runner = CliRunner()
+        result = runner.invoke(catalog_builder_cli, [
+            "download",
+            "--url", _BLOB_URL,
+            "--out", str(dest),
+            "--verbose",
+        ])
+
+        assert result.exit_code == 0
+        assert "reference-architecture" in result.output
+
+    @patch("catalog_builder.cli.download_catalog")
+    def test_download_failure_exits_with_error(self, mock_download):
+        from catalog_builder.catalog_download import CatalogDownloadError
+        mock_download.side_effect = CatalogDownloadError("Connection refused")
+
+        runner = CliRunner()
+        result = runner.invoke(catalog_builder_cli, [
+            "download",
+            "--url", _BLOB_URL,
+        ])
+
+        assert result.exit_code != 0
+        assert "Connection refused" in result.output
+
+    def test_download_requires_url(self):
+        runner = CliRunner()
+        result = runner.invoke(catalog_builder_cli, ["download"])
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()
+
+
+# === architecture-scorer score --catalog-url ===
+
+
+class TestScorerCatalogURL:
+    """Tests for --catalog-url on the scorer CLI."""
+
+    def test_score_help_shows_catalog_url(self):
+        runner = CliRunner()
+        result = runner.invoke(scorer_cli, ["score", "--help"])
+        assert result.exit_code == 0
+        assert "--catalog-url" in result.output
+
+    def test_questions_help_shows_catalog_url(self):
+        runner = CliRunner()
+        result = runner.invoke(scorer_cli, ["questions", "--help"])
+        assert result.exit_code == 0
+        assert "--catalog-url" in result.output
+
+    def test_score_requires_catalog_or_url(self):
+        """Should fail when neither --catalog nor --catalog-url is given."""
+        runner = CliRunner()
+        result = runner.invoke(scorer_cli, [
+            "score",
+            "--context", "/dev/null",
+            "--no-interactive",
+        ])
+        # The _resolve_catalog helper prints an error and exits
+        assert result.exit_code != 0
+
+    @patch("architecture_scorer.cli.download_catalog")
+    @patch("architecture_scorer.cli.ScoringEngine")
+    def test_score_with_catalog_url(self, mock_engine_cls, mock_download, tmp_path):
+        """--catalog-url downloads, then passes the local path to the engine."""
+        # Setup: create a fake context file
+        ctx_file = tmp_path / "ctx.json"
+        ctx_file.write_text(json.dumps({"app_overview": []}))
+
+        dest = tmp_path / "remote-catalog.json"
+        mock_download.return_value = (VALID_CATALOG, dest)
+
+        mock_engine = MagicMock()
+        mock_engine_cls.return_value = mock_engine
+        # Make score() return a result with the minimum fields
+        mock_result = MagicMock()
+        mock_result.clarification_questions = []
+        mock_result.recommendations = []
+        mock_result.processing_warnings = []
+        mock_result.summary.primary_recommendation = "Test"
+        mock_result.summary.confidence_level = "High"
+        mock_result.summary.key_drivers = []
+        mock_result.summary.key_risks = []
+        mock_result.eligible_count = 1
+        mock_result.excluded_count = 0
+        mock_result.application_name = "Test"
+        mock_engine.score.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(scorer_cli, [
+            "score",
+            "--catalog-url", _BLOB_URL,
+            "--context", str(ctx_file),
+            "--no-interactive",
+        ])
+
+        mock_download.assert_called_once_with(_BLOB_URL)
+        mock_engine.load_catalog.assert_called_once_with(str(dest))
+
+    @patch("architecture_scorer.cli.download_catalog")
+    def test_score_catalog_url_download_failure(self, mock_download, tmp_path):
+        from catalog_builder.catalog_download import CatalogDownloadError
+        mock_download.side_effect = CatalogDownloadError("Invalid URL: blocked")
+
+        ctx_file = tmp_path / "ctx.json"
+        ctx_file.write_text(json.dumps({"app_overview": []}))
+
+        runner = CliRunner()
+        result = runner.invoke(scorer_cli, [
+            "score",
+            "--catalog-url", "https://evil.com/bad.json",
+            "--context", str(ctx_file),
+            "--no-interactive",
+        ])
+
+        assert result.exit_code != 0
+        assert "Download failed" in result.output

--- a/tests/test_catalog_loader.py
+++ b/tests/test_catalog_loader.py
@@ -1,4 +1,8 @@
-"""Tests for remote catalog loading with security protections."""
+"""Tests for remote catalog download with security protections.
+
+Tests both the shared catalog_builder.catalog_download module and the
+web-app wrapper in architecture_recommendations_app.utils.catalog_loader.
+"""
 
 import json
 from pathlib import Path
@@ -6,12 +10,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from architecture_recommendations_app.utils.catalog_loader import (
+from catalog_builder.catalog_download import (
     CATALOG_ALLOWED_DOMAINS,
     MAX_ARCHITECTURE_COUNT,
     MAX_CATALOG_BYTES,
-    CatalogLoadError,
+    CatalogDownloadError,
     _validate_catalog_structure,
+    download_catalog,
+)
+
+# Also verify the web-app re-exports work
+from architecture_recommendations_app.utils.catalog_loader import (
+    CatalogLoadError,
     fetch_remote_catalog,
 )
 
@@ -49,6 +59,16 @@ VALID_CATALOG_BYTES = json.dumps(VALID_CATALOG).encode("utf-8")
 _PYDANTIC_PATCH = "catalog_builder.schema.ArchitectureCatalog"
 
 
+# === Re-export alias test ===
+
+
+class TestWebAppReExports:
+    """Ensure the web-app wrapper re-exports the error class correctly."""
+
+    def test_catalog_load_error_is_catalog_download_error(self):
+        assert CatalogLoadError is CatalogDownloadError
+
+
 # === Structure validation tests ===
 
 
@@ -59,29 +79,29 @@ class TestValidateCatalogStructure:
         _validate_catalog_structure(VALID_CATALOG)
 
     def test_rejects_non_dict(self):
-        with pytest.raises(CatalogLoadError, match="JSON object"):
+        with pytest.raises(CatalogDownloadError, match="JSON object"):
             _validate_catalog_structure([1, 2, 3])
 
     def test_rejects_missing_architectures(self):
-        with pytest.raises(CatalogLoadError, match="'architectures' field"):
+        with pytest.raises(CatalogDownloadError, match="'architectures' field"):
             _validate_catalog_structure({"version": "1.0.0"})
 
     def test_rejects_non_list_architectures(self):
-        with pytest.raises(CatalogLoadError, match="JSON array"):
+        with pytest.raises(CatalogDownloadError, match="JSON array"):
             _validate_catalog_structure({"architectures": "not a list", "version": "1"})
 
     def test_rejects_empty_architectures(self):
-        with pytest.raises(CatalogLoadError, match="no architectures"):
+        with pytest.raises(CatalogDownloadError, match="no architectures"):
             _validate_catalog_structure({"architectures": [], "version": "1"})
 
     def test_rejects_too_many_architectures(self):
         catalog = _make_catalog(MAX_ARCHITECTURE_COUNT + 1)
-        with pytest.raises(CatalogLoadError, match="exceeds the maximum"):
+        with pytest.raises(CatalogDownloadError, match="exceeds the maximum"):
             _validate_catalog_structure(catalog)
 
     def test_rejects_missing_version(self):
         data = {"architectures": [{"name": "test"}]}
-        with pytest.raises(CatalogLoadError, match="'version' field"):
+        with pytest.raises(CatalogDownloadError, match="'version' field"):
             _validate_catalog_structure(data)
 
     def test_rejects_entry_without_name_or_id(self):
@@ -89,7 +109,7 @@ class TestValidateCatalogStructure:
             "version": "1.0.0",
             "architectures": [{"description": "no name or id"}],
         }
-        with pytest.raises(CatalogLoadError, match="missing both 'name'"):
+        with pytest.raises(CatalogDownloadError, match="missing both 'name'"):
             _validate_catalog_structure(data)
 
     def test_rejects_non_dict_entry(self):
@@ -97,7 +117,7 @@ class TestValidateCatalogStructure:
             "version": "1.0.0",
             "architectures": ["not a dict"],
         }
-        with pytest.raises(CatalogLoadError, match="not a JSON object"):
+        with pytest.raises(CatalogDownloadError, match="not a JSON object"):
             _validate_catalog_structure(data)
 
     def test_accepts_entry_with_only_name(self):
@@ -105,7 +125,6 @@ class TestValidateCatalogStructure:
         data = _make_catalog()
         for a in data["architectures"]:
             del a["architecture_id"]
-        # Patch Pydantic validation to isolate the structural checks
         with patch(_PYDANTIC_PATCH) as mock_model:
             mock_model.model_validate.return_value = MagicMock()
             _validate_catalog_structure(data)
@@ -114,32 +133,32 @@ class TestValidateCatalogStructure:
 # === URL validation tests ===
 
 
-class TestFetchRemoteCatalogURLValidation:
+class TestURLValidation:
     """Tests that URL validation blocks dangerous URLs."""
 
     def test_rejects_http_url(self):
-        with pytest.raises(CatalogLoadError, match="Invalid URL"):
-            fetch_remote_catalog("http://example.com/catalog.json")
+        with pytest.raises(CatalogDownloadError, match="Invalid URL"):
+            download_catalog("http://example.com/catalog.json")
 
     def test_rejects_private_ip(self):
-        with pytest.raises(CatalogLoadError, match="Invalid URL"):
-            fetch_remote_catalog("https://192.168.1.1/catalog.json")
+        with pytest.raises(CatalogDownloadError, match="Invalid URL"):
+            download_catalog("https://192.168.1.1/catalog.json")
 
     def test_rejects_loopback(self):
-        with pytest.raises(CatalogLoadError, match="Invalid URL"):
-            fetch_remote_catalog("https://127.0.0.1/catalog.json")
+        with pytest.raises(CatalogDownloadError, match="Invalid URL"):
+            download_catalog("https://127.0.0.1/catalog.json")
 
     def test_rejects_metadata_endpoint(self):
-        with pytest.raises(CatalogLoadError, match="Invalid URL"):
-            fetch_remote_catalog("https://169.254.169.254/latest/meta-data/")
+        with pytest.raises(CatalogDownloadError, match="Invalid URL"):
+            download_catalog("https://169.254.169.254/latest/meta-data/")
 
     def test_rejects_non_allowlisted_domain(self):
-        with pytest.raises(CatalogLoadError, match="Invalid URL"):
-            fetch_remote_catalog("https://evil.example.com/catalog.json")
+        with pytest.raises(CatalogDownloadError, match="Invalid URL"):
+            download_catalog("https://evil.example.com/catalog.json")
 
     def test_rejects_ftp_scheme(self):
-        with pytest.raises(CatalogLoadError, match="Invalid URL"):
-            fetch_remote_catalog("ftp://blob.core.windows.net/catalog.json")
+        with pytest.raises(CatalogDownloadError, match="Invalid URL"):
+            download_catalog("ftp://blob.core.windows.net/catalog.json")
 
     def test_allows_azure_blob_domain(self):
         assert "blob.core.windows.net" in CATALOG_ALLOWED_DOMAINS
@@ -149,6 +168,11 @@ class TestFetchRemoteCatalogURLValidation:
 
     def test_allows_microsoft_domain(self):
         assert "microsoft.com" in CATALOG_ALLOWED_DOMAINS
+
+    def test_web_app_wrapper_also_rejects_http(self):
+        """Ensure the web-app wrapper delegates URL validation."""
+        with pytest.raises(CatalogLoadError, match="Invalid URL"):
+            fetch_remote_catalog("http://example.com/catalog.json")
 
 
 # === Network / response handling tests ===
@@ -168,42 +192,46 @@ def _mock_response(
     return resp
 
 
-_REQUESTS_GET = "architecture_recommendations_app.utils.catalog_loader.requests.get"
+# Patch requests.get in the shared module (where the actual call lives)
+_REQUESTS_GET = "catalog_builder.catalog_download.requests.get"
 _BLOB_URL = "https://myaccount.blob.core.windows.net/catalogs/catalog.json"
 
 
-class TestFetchRemoteCatalogNetwork:
-    """Tests for network-level behaviour of fetch_remote_catalog."""
+class TestDownloadCatalogNetwork:
+    """Tests for network-level behaviour of download_catalog."""
 
     @patch(_REQUESTS_GET)
     @patch(_PYDANTIC_PATCH)
-    def test_success_downloads_and_saves(self, mock_model, mock_get):
+    def test_success_downloads_and_saves(self, mock_model, mock_get, tmp_path):
         mock_get.return_value = _mock_response()
         mock_model.model_validate.return_value = MagicMock()
 
-        data, path = fetch_remote_catalog(_BLOB_URL)
+        dest = tmp_path / "catalog.json"
+        data, path = download_catalog(_BLOB_URL, output=dest)
 
         assert "architectures" in data
         assert len(data["architectures"]) == 3
+        assert path == dest
+        assert dest.exists()
         mock_get.assert_called_once()
 
     @patch(_REQUESTS_GET)
     def test_rejects_redirect(self, mock_get):
         mock_get.return_value = _mock_response(status_code=302)
-        with pytest.raises(CatalogLoadError, match="redirect"):
-            fetch_remote_catalog(_BLOB_URL)
+        with pytest.raises(CatalogDownloadError, match="redirect"):
+            download_catalog(_BLOB_URL)
 
     @patch(_REQUESTS_GET)
     def test_rejects_404(self, mock_get):
         mock_get.return_value = _mock_response(status_code=404)
-        with pytest.raises(CatalogLoadError, match="HTTP 404"):
-            fetch_remote_catalog(_BLOB_URL)
+        with pytest.raises(CatalogDownloadError, match="HTTP 404"):
+            download_catalog(_BLOB_URL)
 
     @patch(_REQUESTS_GET)
     def test_rejects_non_json_content_type(self, mock_get):
         mock_get.return_value = _mock_response(content_type="text/html")
-        with pytest.raises(CatalogLoadError, match="Content-Type"):
-            fetch_remote_catalog(_BLOB_URL)
+        with pytest.raises(CatalogDownloadError, match="Content-Type"):
+            download_catalog(_BLOB_URL)
 
     @patch(_REQUESTS_GET)
     def test_rejects_oversized_response(self, mock_get):
@@ -212,8 +240,8 @@ class TestFetchRemoteCatalogNetwork:
         resp.iter_content = MagicMock(return_value=[huge_chunk])
         mock_get.return_value = resp
 
-        with pytest.raises(CatalogLoadError, match="maximum allowed size"):
-            fetch_remote_catalog(_BLOB_URL)
+        with pytest.raises(CatalogDownloadError, match="maximum allowed size"):
+            download_catalog(_BLOB_URL)
 
     @patch(_REQUESTS_GET)
     def test_rejects_empty_response(self, mock_get):
@@ -221,79 +249,79 @@ class TestFetchRemoteCatalogNetwork:
         resp.iter_content = MagicMock(return_value=[])
         mock_get.return_value = resp
 
-        with pytest.raises(CatalogLoadError, match="empty"):
-            fetch_remote_catalog(_BLOB_URL)
+        with pytest.raises(CatalogDownloadError, match="empty"):
+            download_catalog(_BLOB_URL)
 
     @patch(_REQUESTS_GET)
     def test_rejects_invalid_json(self, mock_get):
         mock_get.return_value = _mock_response(content=b"not json {{{")
-        with pytest.raises(CatalogLoadError, match="not valid JSON"):
-            fetch_remote_catalog(_BLOB_URL)
+        with pytest.raises(CatalogDownloadError, match="not valid JSON"):
+            download_catalog(_BLOB_URL)
 
     @patch(_REQUESTS_GET)
     def test_rejects_json_without_architectures_key(self, mock_get):
         mock_get.return_value = _mock_response(
             content=json.dumps({"version": "1.0.0"}).encode()
         )
-        with pytest.raises(CatalogLoadError, match="'architectures' field"):
-            fetch_remote_catalog(_BLOB_URL)
+        with pytest.raises(CatalogDownloadError, match="'architectures' field"):
+            download_catalog(_BLOB_URL)
 
     @patch(_REQUESTS_GET)
     def test_connection_error_gives_friendly_message(self, mock_get):
         import requests as req_lib
         mock_get.side_effect = req_lib.ConnectionError("DNS resolution failed")
-        with pytest.raises(CatalogLoadError, match="Could not connect"):
-            fetch_remote_catalog(_BLOB_URL)
+        with pytest.raises(CatalogDownloadError, match="Could not connect"):
+            download_catalog(_BLOB_URL)
 
     @patch(_REQUESTS_GET)
     def test_timeout_gives_friendly_message(self, mock_get):
         import requests as req_lib
         mock_get.side_effect = req_lib.Timeout("timed out")
-        with pytest.raises(CatalogLoadError, match="timed out"):
-            fetch_remote_catalog(_BLOB_URL)
+        with pytest.raises(CatalogDownloadError, match="timed out"):
+            download_catalog(_BLOB_URL)
 
     @patch(_REQUESTS_GET)
     @patch(_PYDANTIC_PATCH)
-    def test_allows_octet_stream_content_type(self, mock_model, mock_get):
+    def test_allows_octet_stream_content_type(self, mock_model, mock_get, tmp_path):
         """Azure Blob Storage may serve as application/octet-stream."""
         mock_get.return_value = _mock_response(
             content_type="application/octet-stream"
         )
         mock_model.model_validate.return_value = MagicMock()
 
-        data, _ = fetch_remote_catalog(_BLOB_URL)
+        data, _ = download_catalog(_BLOB_URL, output=tmp_path / "c.json")
         assert "architectures" in data
 
     @patch(_REQUESTS_GET)
     @patch(_PYDANTIC_PATCH)
-    def test_allows_no_content_type_header(self, mock_model, mock_get):
+    def test_allows_no_content_type_header(self, mock_model, mock_get, tmp_path):
         """Some servers may omit Content-Type entirely."""
         mock_get.return_value = _mock_response(headers={})
         mock_model.model_validate.return_value = MagicMock()
 
-        data, _ = fetch_remote_catalog(_BLOB_URL)
+        data, _ = download_catalog(_BLOB_URL, output=tmp_path / "c.json")
         assert "architectures" in data
 
     @patch(_REQUESTS_GET)
     @patch(_PYDANTIC_PATCH)
-    def test_disables_redirects(self, mock_model, mock_get):
+    def test_disables_redirects(self, mock_model, mock_get, tmp_path):
         """Ensure allow_redirects=False is set."""
         mock_get.return_value = _mock_response()
         mock_model.model_validate.return_value = MagicMock()
 
-        fetch_remote_catalog(_BLOB_URL)
+        download_catalog(_BLOB_URL, output=tmp_path / "c.json")
 
         _, kwargs = mock_get.call_args
         assert kwargs["allow_redirects"] is False
 
     @patch(_REQUESTS_GET)
     @patch(_PYDANTIC_PATCH)
-    def test_sets_timeout(self, mock_model, mock_get):
+    def test_sets_timeout(self, mock_model, mock_get, tmp_path):
         """Ensure a timeout is set on the request."""
         mock_get.return_value = _mock_response()
         mock_model.model_validate.return_value = MagicMock()
 
-        fetch_remote_catalog(_BLOB_URL)
+        download_catalog(_BLOB_URL, output=tmp_path / "c.json")
 
         _, kwargs = mock_get.call_args
         assert kwargs["timeout"] is not None
@@ -301,5 +329,5 @@ class TestFetchRemoteCatalogNetwork:
     @patch(_REQUESTS_GET)
     def test_rejects_301_redirect(self, mock_get):
         mock_get.return_value = _mock_response(status_code=301)
-        with pytest.raises(CatalogLoadError, match="redirect"):
-            fetch_remote_catalog(_BLOB_URL)
+        with pytest.raises(CatalogDownloadError, match="redirect"):
+            download_catalog(_BLOB_URL)

--- a/tests/test_catalog_loader.py
+++ b/tests/test_catalog_loader.py
@@ -1,0 +1,305 @@
+"""Tests for remote catalog loading with security protections."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from architecture_recommendations_app.utils.catalog_loader import (
+    CATALOG_ALLOWED_DOMAINS,
+    MAX_ARCHITECTURE_COUNT,
+    MAX_CATALOG_BYTES,
+    CatalogLoadError,
+    _validate_catalog_structure,
+    fetch_remote_catalog,
+)
+
+
+# --- Minimal valid catalog for tests ---
+
+def _make_catalog(arch_count: int = 3, **overrides) -> dict:
+    """Build a minimal valid catalog dict."""
+    base = {
+        "version": "1.0.0",
+        "generated_at": "2025-01-15T10:00:00",
+        "source_repo": "https://github.com/MicrosoftDocs/architecture-center",
+        "source_commit": "abc123",
+        "total_architectures": arch_count,
+        "architectures": [
+            {
+                "architecture_id": f"arch-{i}",
+                "name": f"Architecture {i}",
+                "description": f"Test architecture {i}",
+                "source_repo_path": f"docs/arch-{i}",
+                "family": "paas",
+                "workload_domain": "web",
+            }
+            for i in range(arch_count)
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+VALID_CATALOG = _make_catalog()
+VALID_CATALOG_BYTES = json.dumps(VALID_CATALOG).encode("utf-8")
+
+# Patch target for ArchitectureCatalog (imported inside _validate_catalog_structure)
+_PYDANTIC_PATCH = "catalog_builder.schema.ArchitectureCatalog"
+
+
+# === Structure validation tests ===
+
+
+class TestValidateCatalogStructure:
+    """Tests for _validate_catalog_structure."""
+
+    def test_accepts_valid_catalog(self):
+        _validate_catalog_structure(VALID_CATALOG)
+
+    def test_rejects_non_dict(self):
+        with pytest.raises(CatalogLoadError, match="JSON object"):
+            _validate_catalog_structure([1, 2, 3])
+
+    def test_rejects_missing_architectures(self):
+        with pytest.raises(CatalogLoadError, match="'architectures' field"):
+            _validate_catalog_structure({"version": "1.0.0"})
+
+    def test_rejects_non_list_architectures(self):
+        with pytest.raises(CatalogLoadError, match="JSON array"):
+            _validate_catalog_structure({"architectures": "not a list", "version": "1"})
+
+    def test_rejects_empty_architectures(self):
+        with pytest.raises(CatalogLoadError, match="no architectures"):
+            _validate_catalog_structure({"architectures": [], "version": "1"})
+
+    def test_rejects_too_many_architectures(self):
+        catalog = _make_catalog(MAX_ARCHITECTURE_COUNT + 1)
+        with pytest.raises(CatalogLoadError, match="exceeds the maximum"):
+            _validate_catalog_structure(catalog)
+
+    def test_rejects_missing_version(self):
+        data = {"architectures": [{"name": "test"}]}
+        with pytest.raises(CatalogLoadError, match="'version' field"):
+            _validate_catalog_structure(data)
+
+    def test_rejects_entry_without_name_or_id(self):
+        data = {
+            "version": "1.0.0",
+            "architectures": [{"description": "no name or id"}],
+        }
+        with pytest.raises(CatalogLoadError, match="missing both 'name'"):
+            _validate_catalog_structure(data)
+
+    def test_rejects_non_dict_entry(self):
+        data = {
+            "version": "1.0.0",
+            "architectures": ["not a dict"],
+        }
+        with pytest.raises(CatalogLoadError, match="not a JSON object"):
+            _validate_catalog_structure(data)
+
+    def test_accepts_entry_with_only_name(self):
+        """Entry with 'name' but no 'architecture_id' passes structural checks."""
+        data = _make_catalog()
+        for a in data["architectures"]:
+            del a["architecture_id"]
+        # Patch Pydantic validation to isolate the structural checks
+        with patch(_PYDANTIC_PATCH) as mock_model:
+            mock_model.model_validate.return_value = MagicMock()
+            _validate_catalog_structure(data)
+
+
+# === URL validation tests ===
+
+
+class TestFetchRemoteCatalogURLValidation:
+    """Tests that URL validation blocks dangerous URLs."""
+
+    def test_rejects_http_url(self):
+        with pytest.raises(CatalogLoadError, match="Invalid URL"):
+            fetch_remote_catalog("http://example.com/catalog.json")
+
+    def test_rejects_private_ip(self):
+        with pytest.raises(CatalogLoadError, match="Invalid URL"):
+            fetch_remote_catalog("https://192.168.1.1/catalog.json")
+
+    def test_rejects_loopback(self):
+        with pytest.raises(CatalogLoadError, match="Invalid URL"):
+            fetch_remote_catalog("https://127.0.0.1/catalog.json")
+
+    def test_rejects_metadata_endpoint(self):
+        with pytest.raises(CatalogLoadError, match="Invalid URL"):
+            fetch_remote_catalog("https://169.254.169.254/latest/meta-data/")
+
+    def test_rejects_non_allowlisted_domain(self):
+        with pytest.raises(CatalogLoadError, match="Invalid URL"):
+            fetch_remote_catalog("https://evil.example.com/catalog.json")
+
+    def test_rejects_ftp_scheme(self):
+        with pytest.raises(CatalogLoadError, match="Invalid URL"):
+            fetch_remote_catalog("ftp://blob.core.windows.net/catalog.json")
+
+    def test_allows_azure_blob_domain(self):
+        assert "blob.core.windows.net" in CATALOG_ALLOWED_DOMAINS
+
+    def test_allows_github_domain(self):
+        assert "github.com" in CATALOG_ALLOWED_DOMAINS
+
+    def test_allows_microsoft_domain(self):
+        assert "microsoft.com" in CATALOG_ALLOWED_DOMAINS
+
+
+# === Network / response handling tests ===
+
+
+def _mock_response(
+    status_code=200,
+    content=VALID_CATALOG_BYTES,
+    content_type="application/json",
+    headers=None,
+):
+    """Build a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {"Content-Type": content_type}
+    resp.iter_content = MagicMock(return_value=[content])
+    return resp
+
+
+_REQUESTS_GET = "architecture_recommendations_app.utils.catalog_loader.requests.get"
+_BLOB_URL = "https://myaccount.blob.core.windows.net/catalogs/catalog.json"
+
+
+class TestFetchRemoteCatalogNetwork:
+    """Tests for network-level behaviour of fetch_remote_catalog."""
+
+    @patch(_REQUESTS_GET)
+    @patch(_PYDANTIC_PATCH)
+    def test_success_downloads_and_saves(self, mock_model, mock_get):
+        mock_get.return_value = _mock_response()
+        mock_model.model_validate.return_value = MagicMock()
+
+        data, path = fetch_remote_catalog(_BLOB_URL)
+
+        assert "architectures" in data
+        assert len(data["architectures"]) == 3
+        mock_get.assert_called_once()
+
+    @patch(_REQUESTS_GET)
+    def test_rejects_redirect(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=302)
+        with pytest.raises(CatalogLoadError, match="redirect"):
+            fetch_remote_catalog(_BLOB_URL)
+
+    @patch(_REQUESTS_GET)
+    def test_rejects_404(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=404)
+        with pytest.raises(CatalogLoadError, match="HTTP 404"):
+            fetch_remote_catalog(_BLOB_URL)
+
+    @patch(_REQUESTS_GET)
+    def test_rejects_non_json_content_type(self, mock_get):
+        mock_get.return_value = _mock_response(content_type="text/html")
+        with pytest.raises(CatalogLoadError, match="Content-Type"):
+            fetch_remote_catalog(_BLOB_URL)
+
+    @patch(_REQUESTS_GET)
+    def test_rejects_oversized_response(self, mock_get):
+        huge_chunk = b"x" * (MAX_CATALOG_BYTES + 1)
+        resp = _mock_response()
+        resp.iter_content = MagicMock(return_value=[huge_chunk])
+        mock_get.return_value = resp
+
+        with pytest.raises(CatalogLoadError, match="maximum allowed size"):
+            fetch_remote_catalog(_BLOB_URL)
+
+    @patch(_REQUESTS_GET)
+    def test_rejects_empty_response(self, mock_get):
+        resp = _mock_response()
+        resp.iter_content = MagicMock(return_value=[])
+        mock_get.return_value = resp
+
+        with pytest.raises(CatalogLoadError, match="empty"):
+            fetch_remote_catalog(_BLOB_URL)
+
+    @patch(_REQUESTS_GET)
+    def test_rejects_invalid_json(self, mock_get):
+        mock_get.return_value = _mock_response(content=b"not json {{{")
+        with pytest.raises(CatalogLoadError, match="not valid JSON"):
+            fetch_remote_catalog(_BLOB_URL)
+
+    @patch(_REQUESTS_GET)
+    def test_rejects_json_without_architectures_key(self, mock_get):
+        mock_get.return_value = _mock_response(
+            content=json.dumps({"version": "1.0.0"}).encode()
+        )
+        with pytest.raises(CatalogLoadError, match="'architectures' field"):
+            fetch_remote_catalog(_BLOB_URL)
+
+    @patch(_REQUESTS_GET)
+    def test_connection_error_gives_friendly_message(self, mock_get):
+        import requests as req_lib
+        mock_get.side_effect = req_lib.ConnectionError("DNS resolution failed")
+        with pytest.raises(CatalogLoadError, match="Could not connect"):
+            fetch_remote_catalog(_BLOB_URL)
+
+    @patch(_REQUESTS_GET)
+    def test_timeout_gives_friendly_message(self, mock_get):
+        import requests as req_lib
+        mock_get.side_effect = req_lib.Timeout("timed out")
+        with pytest.raises(CatalogLoadError, match="timed out"):
+            fetch_remote_catalog(_BLOB_URL)
+
+    @patch(_REQUESTS_GET)
+    @patch(_PYDANTIC_PATCH)
+    def test_allows_octet_stream_content_type(self, mock_model, mock_get):
+        """Azure Blob Storage may serve as application/octet-stream."""
+        mock_get.return_value = _mock_response(
+            content_type="application/octet-stream"
+        )
+        mock_model.model_validate.return_value = MagicMock()
+
+        data, _ = fetch_remote_catalog(_BLOB_URL)
+        assert "architectures" in data
+
+    @patch(_REQUESTS_GET)
+    @patch(_PYDANTIC_PATCH)
+    def test_allows_no_content_type_header(self, mock_model, mock_get):
+        """Some servers may omit Content-Type entirely."""
+        mock_get.return_value = _mock_response(headers={})
+        mock_model.model_validate.return_value = MagicMock()
+
+        data, _ = fetch_remote_catalog(_BLOB_URL)
+        assert "architectures" in data
+
+    @patch(_REQUESTS_GET)
+    @patch(_PYDANTIC_PATCH)
+    def test_disables_redirects(self, mock_model, mock_get):
+        """Ensure allow_redirects=False is set."""
+        mock_get.return_value = _mock_response()
+        mock_model.model_validate.return_value = MagicMock()
+
+        fetch_remote_catalog(_BLOB_URL)
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["allow_redirects"] is False
+
+    @patch(_REQUESTS_GET)
+    @patch(_PYDANTIC_PATCH)
+    def test_sets_timeout(self, mock_model, mock_get):
+        """Ensure a timeout is set on the request."""
+        mock_get.return_value = _mock_response()
+        mock_model.model_validate.return_value = MagicMock()
+
+        fetch_remote_catalog(_BLOB_URL)
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["timeout"] is not None
+
+    @patch(_REQUESTS_GET)
+    def test_rejects_301_redirect(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=301)
+        with pytest.raises(CatalogLoadError, match="redirect"):
+            fetch_remote_catalog(_BLOB_URL)


### PR DESCRIPTION
Add ability to upload generated catalog JSON to Azure Blob Storage,
supporting three authentication methods: SAS URL, connection string,
and DefaultAzureCredential. Includes a standalone `upload` CLI command
and a `--upload-url` convenience option on `build-catalog` for CI/CD
pipelines that build and publish in a single step.

- New `blob_upload.py` module with upload logic and metadata extraction
- New `upload` CLI command with full auth method support
- `--upload-url` option on `build-catalog` for inline upload after build
- Optional `[azure]` dependency group (azure-storage-blob, azure-identity)
- 24 tests covering metadata extraction, auth routing, and CLI integration
- New docs/blob-storage-upload.md with CI/CD examples and troubleshooting
- Updated catalog-builder docs, GitHub Pages nav, and CLAUDE.md

https://claude.ai/code/session_01DBcJru9uorJBPn2qFfhwJn